### PR TITLE
Add initial local controller foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@ Match the style of surrounding code.
 Use existing libraries and utilities before adding new dependencies.
 Prefer procedural programming over object-oriented programming.
 Use functions and modules over classes when possible.
+Do not introduce receiver functions on project types by default.
+Prefer plain package-level functions that take explicit arguments.
+Only use receiver functions when there is a clear external constraint, such as implementing a required library interface.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ Use functions and modules over classes when possible.
 Do not introduce receiver functions on project types by default.
 Prefer plain package-level functions that take explicit arguments.
 Only use receiver functions when there is a clear external constraint, such as implementing a required library interface.
+Prefer `fmt.Errorf` for constructed errors in normal control flow.
+Reserve `errors.New` for sentinel error variables that are compared or reused.
+When accumulating multiple independent errors, prefer an `error` accumulator with `errors.Join` over building ad hoc string lists.
+When several independent validations happen in the same block, prefer a single grouped `errors.Join(...)` call over repetitive one-line joins.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ It should be a concise summary of the change.
 Leave a blank line after the first line.
 Body text should wrap at 72 characters.
 Use the body to explain the what and why rather than the how.
+When creating commit messages from the shell, do not embed literal `\n` escape sequences in `git commit -m` arguments.
+Prefer `git commit -F -` with a heredoc for multi-line messages.
+Using multiple `-m` flags is acceptable for short messages when the body does not need careful wrapping.
 
 Example:
 

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -16,62 +16,59 @@ import (
 )
 
 func main() {
-	logger := slog.Default()
-
 	configPath := flag.String("config", "", "Path to config file")
 	validateOnly := flag.Bool("validate", false, "Validate config and exit")
 	flag.Parse()
 
 	configRoot, err := config.Load(*configPath)
 	if err != nil {
-		logger.Error("load config failed", "error", err)
+		slog.Error("load config failed", "error", err)
 		os.Exit(1)
 	}
 
 	if *validateOnly {
-		logger.Info("config is valid", "path", *configPath)
+		slog.Info("config is valid", "path", *configPath)
 		return
 	}
 
 	root := entity.FromConfig(configRoot)
 	index := registry.Build(root)
 
-	logger.Info("crawling sysfs device tree", "root", root.SysfsRoot)
+	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
 	devices, err := sysfs.ListDevices(root.SysfsRoot)
 	if err != nil {
-		logger.Error("crawl failed", "error", err)
+		slog.Error("crawl failed", "error", err)
 		return
 	}
 
 	configuredDevices, missing := configuredDevices(devices, registry.DeviceIDs(index))
 	if len(missing) > 0 {
 		for _, deviceID := range missing {
-			logger.Error("configured device not found in sysfs", "device_id", deviceID)
+			slog.Error("configured device not found in sysfs", "device_id", deviceID)
 		}
 		os.Exit(1)
 	}
 
-	logger.Info("configured devices", "count", len(configuredDevices))
+	slog.Info("configured devices", "count", len(configuredDevices))
 	for _, device := range configuredDevices {
-		logger.Info("configured device", "identifier", device.Identifier, "path", device.Path)
+		slog.Info("configured device", "identifier", device.Identifier, "path", device.Path)
 	}
 
 	configs := sysfs.BuildWorkerConfigs(configuredDevices)
 
 	stopChs, pollEvents := sysfs.StartWorkers(configs)
 
-	logger.Info("polling devices", "message", "press Ctrl+C to exit")
+	slog.Info("polling devices", "message", "press Ctrl+C to exit")
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	dispatch(logger, index, pollEvents, sigCh)
+	dispatch(index, pollEvents, sigCh)
 
-	logger.Info("shutting down")
+	slog.Info("shutting down")
 	sysfs.StopWorkers(stopChs)
 }
 
 func dispatch(
-	logger *slog.Logger,
 	index *registry.Index,
 	pollEvents <-chan sysfs.PollEvent,
 	sigCh <-chan os.Signal,
@@ -85,19 +82,19 @@ func dispatch(
 				return
 			}
 
-			handlePollEvent(logger, index, pollEvent)
+			handlePollEvent(index, pollEvent)
 		}
 	}
 }
 
-func handlePollEvent(logger *slog.Logger, index *registry.Index, pollEvent sysfs.PollEvent) {
+func handlePollEvent(index *registry.Index, pollEvent sysfs.PollEvent) {
 	digitalInputEvent, ok := event.PollEventToDigitalInputEvent(index, pollEvent)
 	if ok {
-		handleEvent(logger, index, digitalInputEvent)
+		handleEvent(index, digitalInputEvent)
 		return
 	}
 
-	logger.Info(
+	slog.Info(
 		"poll event",
 		"identifier",
 		pollEvent.Device.Identifier,
@@ -112,10 +109,10 @@ func handlePollEvent(logger *slog.Logger, index *registry.Index, pollEvent sysfs
 	)
 }
 
-func handleEvent(logger *slog.Logger, index *registry.Index, busEvent event.Event) {
+func handleEvent(index *registry.Index, busEvent event.Event) {
 	switch busEvent.Kind {
 	case event.DigitalInputKind:
-		logger.Info(
+		slog.Info(
 			"digital input event",
 			"input_id",
 			busEvent.DigitalInput.InputID,
@@ -128,10 +125,10 @@ func handleEvent(logger *slog.Logger, index *registry.Index, busEvent event.Even
 		)
 
 		for _, pushButtonEvent := range event.DigitalInputEventToPushButtonEvents(index, *busEvent.DigitalInput) {
-			handleEvent(logger, index, pushButtonEvent)
+			handleEvent(index, pushButtonEvent)
 		}
 	case event.PushButtonKind:
-		logger.Info(
+		slog.Info(
 			"push button event",
 			"button_id",
 			busEvent.PushButton.ButtonID,

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 
 	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/controller"
 	"github.com/mhemeryck/nest/internal/entity"
-	"github.com/mhemeryck/nest/internal/event"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
@@ -62,82 +62,10 @@ func main() {
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	dispatch(index, pollEvents, sigCh)
+	controller.Run(index, pollEvents, sigCh)
 
 	slog.Info("shutting down")
 	sysfs.StopWorkers(stopChs)
-}
-
-func dispatch(
-	index *registry.Index,
-	pollEvents <-chan sysfs.PollEvent,
-	sigCh <-chan os.Signal,
-) {
-	for {
-		select {
-		case <-sigCh:
-			return
-		case pollEvent, ok := <-pollEvents:
-			if !ok {
-				return
-			}
-
-			handlePollEvent(index, pollEvent)
-		}
-	}
-}
-
-func handlePollEvent(index *registry.Index, pollEvent sysfs.PollEvent) {
-	digitalInputEvent, ok := event.PollEventToDigitalInputEvent(index, pollEvent)
-	if ok {
-		handleEvent(index, digitalInputEvent)
-		return
-	}
-
-	slog.Info(
-		"poll event",
-		"identifier",
-		pollEvent.Device.Identifier,
-		"path",
-		pollEvent.Device.Path,
-		"old_value",
-		sysfs.PrintableValue(pollEvent.OldValue),
-		"new_value",
-		sysfs.PrintableValue(pollEvent.NewValue),
-		"rising",
-		pollEvent.IsRising,
-	)
-}
-
-func handleEvent(index *registry.Index, busEvent event.Event) {
-	switch busEvent.Kind {
-	case event.DigitalInputKind:
-		slog.Info(
-			"digital input event",
-			"input_id",
-			busEvent.DigitalInput.InputID,
-			"device_id",
-			busEvent.DigitalInput.DeviceID,
-			"rising",
-			busEvent.DigitalInput.IsRising,
-			"falling",
-			busEvent.DigitalInput.IsFalling,
-		)
-
-		for _, pushButtonEvent := range event.DigitalInputEventToPushButtonEvents(index, *busEvent.DigitalInput) {
-			handleEvent(index, pushButtonEvent)
-		}
-	case event.PushButtonKind:
-		slog.Info(
-			"push button event",
-			"button_id",
-			busEvent.PushButton.ButtonID,
-			"name",
-			busEvent.PushButton.Name,
-			"kind",
-			busEvent.PushButton.Kind,
-		)
-	}
 }
 
 func configuredDevices(devices []*sysfs.Device, wanted []string) ([]*sysfs.Device, []string) {

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -1,30 +1,54 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"sort"
 	"syscall"
 
+	"github.com/mhemeryck/nest/internal/config"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
 func main() {
-	root := "/home/mhemeryck/Projects/nest/test/fixtures"
+	configPath := flag.String("config", "", "Path to config file")
+	validateOnly := flag.Bool("validate", false, "Validate config and exit")
+	flag.Parse()
 
-	fmt.Println("Crawling sysfs device tree...")
-	devices, err := sysfs.ListDevices(root)
+	file, err := config.Load(*configPath)
 	if err != nil {
-		log.Printf("Crawl failed: %v", err)
-	} else {
-		fmt.Printf("Found %d devices\n", len(devices))
-		for _, d := range devices[:5] {
-			fmt.Printf("  %s (%s)\n", d.Identifier, d.Path)
-		}
+		log.Fatalf("Load config failed: %v", err)
 	}
 
-	configs := sysfs.BuildWorkerConfigs(devices)
+	if *validateOnly {
+		fmt.Printf("Config is valid: %s\n", *configPath)
+		return
+	}
+
+	fmt.Println("Crawling sysfs device tree...")
+	devices, err := sysfs.ListDevices(file.Sysfs.Root)
+	if err != nil {
+		log.Printf("Crawl failed: %v", err)
+		return
+	}
+
+	configuredDevices, missing := configuredDevices(devices, config.DeviceIDs(file))
+	if len(missing) > 0 {
+		for _, deviceID := range missing {
+			log.Printf("Configured device not found in sysfs: %s", deviceID)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("Configured %d devices\n", len(configuredDevices))
+	for _, device := range configuredDevices {
+		fmt.Printf("  %s (%s)\n", device.Identifier, device.Path)
+	}
+
+	configs := sysfs.BuildWorkerConfigs(configuredDevices)
 
 	stopChs, events := sysfs.StartWorkers(configs)
 
@@ -48,4 +72,25 @@ func main() {
 
 	fmt.Println("\nShutting down...")
 	sysfs.StopWorkers(stopChs)
+}
+
+func configuredDevices(devices []*sysfs.Device, wanted []string) ([]*sysfs.Device, []string) {
+	byIdentifier := make(map[string]*sysfs.Device, len(devices))
+	for _, device := range devices {
+		byIdentifier[device.Identifier] = device
+	}
+
+	configured := make([]*sysfs.Device, 0, len(wanted))
+	missing := make([]string, 0)
+	for _, identifier := range wanted {
+		device, ok := byIdentifier[identifier]
+		if !ok {
+			missing = append(missing, identifier)
+			continue
+		}
+		configured = append(configured, device)
+	}
+
+	sort.Strings(missing)
+	return configured, missing
 }

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -38,7 +38,7 @@ func main() {
 	devices, err := sysfs.ListDevices(root.SysfsRoot)
 	if err != nil {
 		slog.Error("crawl failed", "error", err)
-		return
+		os.Exit(1)
 	}
 
 	configuredDevices, missing := configuredDevices(devices, registry.DeviceIDs(index))

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/event"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
@@ -21,7 +22,7 @@ func main() {
 	validateOnly := flag.Bool("validate", false, "Validate config and exit")
 	flag.Parse()
 
-	file, err := config.Load(*configPath)
+	configRoot, err := config.Load(*configPath)
 	if err != nil {
 		logger.Error("load config failed", "error", err)
 		os.Exit(1)
@@ -32,10 +33,11 @@ func main() {
 		return
 	}
 
-	index := registry.Build(file)
+	root := entity.FromConfig(configRoot)
+	index := registry.Build(root)
 
-	logger.Info("crawling sysfs device tree", "root", file.Sysfs.Root)
-	devices, err := sysfs.ListDevices(file.Sysfs.Root)
+	logger.Info("crawling sysfs device tree", "root", root.SysfsRoot)
+	devices, err := sysfs.ListDevices(root.SysfsRoot)
 	if err != nil {
 		logger.Error("crawl failed", "error", err)
 		return

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"sort"
+	"slices"
 	"syscall"
 
 	"github.com/mhemeryck/nest/internal/config"
@@ -68,16 +68,16 @@ func main() {
 	sysfs.StopWorkers(stopChs)
 }
 
-func configuredDevices(devices []*sysfs.Device, wanted []string) ([]*sysfs.Device, []string) {
+func configuredDevices(devices []*sysfs.Device, wanted []entity.DeviceID) ([]*sysfs.Device, []entity.DeviceID) {
 	byIdentifier := make(map[string]*sysfs.Device, len(devices))
 	for _, device := range devices {
 		byIdentifier[device.Identifier] = device
 	}
 
 	configured := make([]*sysfs.Device, 0, len(wanted))
-	missing := make([]string, 0)
+	missing := make([]entity.DeviceID, 0)
 	for _, identifier := range wanted {
-		device, ok := byIdentifier[identifier]
+		device, ok := byIdentifier[string(identifier)]
 		if !ok {
 			missing = append(missing, identifier)
 			continue
@@ -85,6 +85,7 @@ func configuredDevices(devices []*sysfs.Device, wanted []string) ([]*sysfs.Devic
 		configured = append(configured, device)
 	}
 
-	sort.Strings(missing)
+	slices.Sort(missing)
+
 	return configured, missing
 }

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -101,9 +101,9 @@ func handlePollEvent(index *registry.Index, pollEvent sysfs.PollEvent) {
 		"path",
 		pollEvent.Device.Path,
 		"old_value",
-		int(pollEvent.OldValue-'0'),
+		sysfs.PrintableValue(pollEvent.OldValue),
 		"new_value",
-		int(pollEvent.NewValue-'0'),
+		sysfs.PrintableValue(pollEvent.NewValue),
 		"rising",
 		pollEvent.IsRising,
 	)

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -59,73 +59,88 @@ func main() {
 	configs := sysfs.BuildWorkerConfigs(configuredDevices)
 
 	stopChs, pollEvents := sysfs.StartWorkers(configs)
-	bus := event.NewBus(32)
-
-	go func() {
-		for pollEvent := range pollEvents {
-			digitalInputEvent, ok := event.PollEventToDigitalInputEvent(index, pollEvent)
-			if ok {
-				bus <- digitalInputEvent
-				continue
-			}
-
-			logger.Info(
-				"poll event",
-				"identifier",
-				pollEvent.Device.Identifier,
-				"path",
-				pollEvent.Device.Path,
-				"old_value",
-				int(pollEvent.OldValue-'0'),
-				"new_value",
-				int(pollEvent.NewValue-'0'),
-				"rising",
-				pollEvent.IsRising,
-			)
-		}
-	}()
-
-	go func() {
-		for busEvent := range bus {
-			switch busEvent.Kind {
-			case event.DigitalInputKind:
-				logger.Info(
-					"digital input event",
-					"input_id",
-					busEvent.DigitalInput.InputID,
-					"device_id",
-					busEvent.DigitalInput.DeviceID,
-					"rising",
-					busEvent.DigitalInput.IsRising,
-					"falling",
-					busEvent.DigitalInput.IsFalling,
-				)
-
-				for _, pushButtonEvent := range event.DigitalInputEventToPushButtonEvents(index, *busEvent.DigitalInput) {
-					bus <- pushButtonEvent
-				}
-			case event.PushButtonKind:
-				logger.Info(
-					"push button event",
-					"button_id",
-					busEvent.PushButton.ButtonID,
-					"name",
-					busEvent.PushButton.Name,
-					"kind",
-					busEvent.PushButton.Kind,
-				)
-			}
-		}
-	}()
 
 	logger.Info("polling devices", "message", "press Ctrl+C to exit")
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
+	dispatch(logger, index, pollEvents, sigCh)
 
 	logger.Info("shutting down")
 	sysfs.StopWorkers(stopChs)
+}
+
+func dispatch(
+	logger *slog.Logger,
+	index *registry.Index,
+	pollEvents <-chan sysfs.PollEvent,
+	sigCh <-chan os.Signal,
+) {
+	for {
+		select {
+		case <-sigCh:
+			return
+		case pollEvent, ok := <-pollEvents:
+			if !ok {
+				return
+			}
+
+			handlePollEvent(logger, index, pollEvent)
+		}
+	}
+}
+
+func handlePollEvent(logger *slog.Logger, index *registry.Index, pollEvent sysfs.PollEvent) {
+	digitalInputEvent, ok := event.PollEventToDigitalInputEvent(index, pollEvent)
+	if ok {
+		handleEvent(logger, index, digitalInputEvent)
+		return
+	}
+
+	logger.Info(
+		"poll event",
+		"identifier",
+		pollEvent.Device.Identifier,
+		"path",
+		pollEvent.Device.Path,
+		"old_value",
+		int(pollEvent.OldValue-'0'),
+		"new_value",
+		int(pollEvent.NewValue-'0'),
+		"rising",
+		pollEvent.IsRising,
+	)
+}
+
+func handleEvent(logger *slog.Logger, index *registry.Index, busEvent event.Event) {
+	switch busEvent.Kind {
+	case event.DigitalInputKind:
+		logger.Info(
+			"digital input event",
+			"input_id",
+			busEvent.DigitalInput.InputID,
+			"device_id",
+			busEvent.DigitalInput.DeviceID,
+			"rising",
+			busEvent.DigitalInput.IsRising,
+			"falling",
+			busEvent.DigitalInput.IsFalling,
+		)
+
+		for _, pushButtonEvent := range event.DigitalInputEventToPushButtonEvents(index, *busEvent.DigitalInput) {
+			handleEvent(logger, index, pushButtonEvent)
+		}
+	case event.PushButtonKind:
+		logger.Info(
+			"push button event",
+			"button_id",
+			busEvent.PushButton.ButtonID,
+			"name",
+			busEvent.PushButton.Name,
+			"kind",
+			busEvent.PushButton.Kind,
+		)
+	}
 }
 
 func configuredDevices(devices []*sysfs.Device, wanted []string) ([]*sysfs.Device, []string) {

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"sort"
@@ -16,40 +15,43 @@ import (
 )
 
 func main() {
+	logger := slog.Default()
+
 	configPath := flag.String("config", "", "Path to config file")
 	validateOnly := flag.Bool("validate", false, "Validate config and exit")
 	flag.Parse()
 
 	file, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("Load config failed: %v", err)
+		logger.Error("load config failed", "error", err)
+		os.Exit(1)
 	}
 
 	if *validateOnly {
-		fmt.Printf("Config is valid: %s\n", *configPath)
+		logger.Info("config is valid", "path", *configPath)
 		return
 	}
 
 	index := registry.Build(file)
 
-	fmt.Println("Crawling sysfs device tree...")
+	logger.Info("crawling sysfs device tree", "root", file.Sysfs.Root)
 	devices, err := sysfs.ListDevices(file.Sysfs.Root)
 	if err != nil {
-		log.Printf("Crawl failed: %v", err)
+		logger.Error("crawl failed", "error", err)
 		return
 	}
 
 	configuredDevices, missing := configuredDevices(devices, registry.DeviceIDs(index))
 	if len(missing) > 0 {
 		for _, deviceID := range missing {
-			log.Printf("Configured device not found in sysfs: %s", deviceID)
+			logger.Error("configured device not found in sysfs", "device_id", deviceID)
 		}
 		os.Exit(1)
 	}
 
-	fmt.Printf("Configured %d devices\n", len(configuredDevices))
+	logger.Info("configured devices", "count", len(configuredDevices))
 	for _, device := range configuredDevices {
-		fmt.Printf("  %s (%s)\n", device.Identifier, device.Path)
+		logger.Info("configured device", "identifier", device.Identifier, "path", device.Path)
 	}
 
 	configs := sysfs.BuildWorkerConfigs(configuredDevices)
@@ -65,11 +67,17 @@ func main() {
 				continue
 			}
 
-			fmt.Printf("%s (%s): %d -> %d (rising=%t)\n",
+			logger.Info(
+				"poll event",
+				"identifier",
 				pollEvent.Device.Identifier,
+				"path",
 				pollEvent.Device.Path,
+				"old_value",
 				int(pollEvent.OldValue-'0'),
+				"new_value",
 				int(pollEvent.NewValue-'0'),
+				"rising",
 				pollEvent.IsRising,
 			)
 		}
@@ -79,10 +87,15 @@ func main() {
 		for busEvent := range bus {
 			switch busEvent.Kind {
 			case event.DigitalInputKind:
-				fmt.Printf("digital_input %s (%s): rising=%t falling=%t\n",
+				logger.Info(
+					"digital input event",
+					"input_id",
 					busEvent.DigitalInput.InputID,
+					"device_id",
 					busEvent.DigitalInput.DeviceID,
+					"rising",
 					busEvent.DigitalInput.IsRising,
+					"falling",
 					busEvent.DigitalInput.IsFalling,
 				)
 
@@ -90,22 +103,26 @@ func main() {
 					bus <- pushButtonEvent
 				}
 			case event.PushButtonKind:
-				fmt.Printf("push_button %s (%s): kind=%s\n",
+				logger.Info(
+					"push button event",
+					"button_id",
 					busEvent.PushButton.ButtonID,
+					"name",
 					busEvent.PushButton.Name,
+					"kind",
 					busEvent.PushButton.Kind,
 				)
 			}
 		}
 	}()
 
-	fmt.Println("Polling devices... Press Ctrl+C to exit")
+	logger.Info("polling devices", "message", "press Ctrl+C to exit")
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	<-sigCh
 
-	fmt.Println("\nShutting down...")
+	logger.Info("shutting down")
 	sysfs.StopWorkers(stopChs)
 }
 

--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 
 	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/event"
+	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
@@ -28,6 +30,8 @@ func main() {
 		return
 	}
 
+	index := registry.Build(file)
+
 	fmt.Println("Crawling sysfs device tree...")
 	devices, err := sysfs.ListDevices(file.Sysfs.Root)
 	if err != nil {
@@ -35,7 +39,7 @@ func main() {
 		return
 	}
 
-	configuredDevices, missing := configuredDevices(devices, config.DeviceIDs(file))
+	configuredDevices, missing := configuredDevices(devices, registry.DeviceIDs(index))
 	if len(missing) > 0 {
 		for _, deviceID := range missing {
 			log.Printf("Configured device not found in sysfs: %s", deviceID)
@@ -50,17 +54,48 @@ func main() {
 
 	configs := sysfs.BuildWorkerConfigs(configuredDevices)
 
-	stopChs, events := sysfs.StartWorkers(configs)
+	stopChs, pollEvents := sysfs.StartWorkers(configs)
+	bus := event.NewBus(32)
 
 	go func() {
-		for event := range events {
+		for pollEvent := range pollEvents {
+			digitalInputEvent, ok := event.PollEventToDigitalInputEvent(index, pollEvent)
+			if ok {
+				bus <- digitalInputEvent
+				continue
+			}
+
 			fmt.Printf("%s (%s): %d -> %d (rising=%t)\n",
-				event.Device.Identifier,
-				event.Device.Path,
-				int(event.OldValue-'0'),
-				int(event.NewValue-'0'),
-				event.IsRising,
+				pollEvent.Device.Identifier,
+				pollEvent.Device.Path,
+				int(pollEvent.OldValue-'0'),
+				int(pollEvent.NewValue-'0'),
+				pollEvent.IsRising,
 			)
+		}
+	}()
+
+	go func() {
+		for busEvent := range bus {
+			switch busEvent.Kind {
+			case event.DigitalInputKind:
+				fmt.Printf("digital_input %s (%s): rising=%t falling=%t\n",
+					busEvent.DigitalInput.InputID,
+					busEvent.DigitalInput.DeviceID,
+					busEvent.DigitalInput.IsRising,
+					busEvent.DigitalInput.IsFalling,
+				)
+
+				for _, pushButtonEvent := range event.DigitalInputEventToPushButtonEvents(index, *busEvent.DigitalInput) {
+					bus <- pushButtonEvent
+				}
+			case event.PushButtonKind:
+				fmt.Printf("push_button %s (%s): kind=%s\n",
+					busEvent.PushButton.ButtonID,
+					busEvent.PushButton.Name,
+					busEvent.PushButton.Kind,
+				)
+			}
 		}
 	}()
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ codebase.
 
 - [Overview](architecture.md) - High-level system architecture and guiding principles
 - [Design](design.md) - Target design for `nest` as the consolidated controller
+- [Long-Term Ideas](ideas.md) - Parked ideas and future directions
 - [Repositories](repos.md) - Overview of existing repositories, roles, and migration context
 - [Covers](covers.md) - Cover controller behavior, legacy approach, and planned `nest` implementation
 - [Sysfs](sysfs.md) - Unipi sysfs interface and how `nest` uses or plans to use it

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,0 +1,46 @@
+# Long-Term Ideas
+
+This document is for ideas that seem useful but are not part of the
+current implementation slice.
+Keep items here short so they are easy to scan and revisit later.
+
+## Input Model
+
+- Add richer push button semantics such as `released`, `long_press`, and repeated presses.
+- Support multiple push buttons bound to the same digital input when that turns out to be useful.
+- Add debounce handling as part of the input event pipeline rather than inside sysfs polling.
+
+## Automation Model
+
+- Add bindings from push button events to relay, motor, or cover actions.
+- Add an automation handler that consumes semantic events from the shared event bus.
+- Define a small action model so event handlers produce explicit commands instead of directly mutating hardware state.
+
+## Actuator Model
+
+- Introduce motors as first-class local actuators composed of two relays.
+- Build covers on top of motors instead of wiring covers directly to relays.
+- Track motor state separately from cover state when that improves restart and recovery behavior.
+
+## Event System
+
+- Extend the tagged-union event model with actuator and automation events.
+- Add event tracing or structured logging to make event flows easier to debug.
+- Decide whether the event bus should stay as a single in-process channel or evolve into a dispatcher with subscriptions.
+
+## Transport And Integration
+
+- Reintroduce MQTT as a thin external interface once local semantics are stable.
+- Add Modbus RTU for inter-unit control after the local control loop is proven.
+- Revisit Home Assistant auto-discovery once the external contract is stable.
+- If Home Assistant MQTT auto-discovery is added, expose the MQTT-facing options already modeled by `nest` rather than inventing a separate HA-specific configuration layer.
+- Expose an API for managing configuration so external tools can program controller state.
+- Explore a Terraform provider that manages `nest` configuration through that API.
+
+## Operations
+
+- Add a dedicated `validate` command instead of only a `-validate` flag if the CLI grows.
+- Add example configs for common unit roles such as input-only, relay-only, and local cover control.
+- Decide how much configuration should be checked against live sysfs state at startup.
+- Expose a local web UI for controller inspection and configuration.
+- Keep the web UI simple and server-driven, using something like `htmx` rather than a heavy frontend framework.

--- a/docs/phase-2-proposal.md
+++ b/docs/phase-2-proposal.md
@@ -1,0 +1,259 @@
+# Phase 2 Proposal
+
+## Goal
+
+Phase 2 should introduce the smallest config model that lets `nest` describe one local unit.
+That model should be enough to wire local inputs, relays, and a first cover entity without pulling in MQTT or Modbus concerns.
+
+This keeps the next phase focused on cover behavior rather than config redesign.
+
+## Scope
+
+Phase 2 should deliver four concrete things.
+
+1. A YAML file format for one unit.
+2. A loader that reads and validates that file.
+3. Internal types that represent local inputs, relays, and covers.
+4. A CLI entrypoint that accepts a config path instead of hardcoding fixture paths.
+
+Phase 2 should not include transport config, Home Assistant integration, or distributed mappings.
+
+## Proposed Config Shape
+
+This proposal keeps the file local-only.
+It borrows the cover example from `docs/design.md`, but makes identifiers explicit so later phases can reference entities without depending on display names.
+
+```yaml
+sysfs:
+  root: /
+
+inputs:
+  - id: office-shade-button
+    name: Office shade toggle
+    device: di_2_15
+
+relays:
+  - id: office-shade-up
+    name: Office shade up
+    device: ro_3_14
+  - id: office-shade-down
+    name: Office shade down
+    device: ro_3_13
+
+covers:
+  - id: office
+    name: Office shade
+    up_relay: office-shade-up
+    down_relay: office-shade-down
+    max_time: 30s
+
+bindings:
+  - input: office-shade-button
+    target: office
+    action: toggle
+```
+
+## Why This Shape
+
+This shape keeps hardware details at the edges.
+Inputs and relays map directly to sysfs device identifiers.
+Entities such as covers reference relay ids rather than raw sysfs names.
+
+That gives us a clear separation.
+
+1. Hardware inventory: `inputs` and `relays`.
+2. Local domain entities: `covers`.
+3. Behavior wiring: `bindings`.
+
+This is enough for the single-unit shade slice described in the implementation plan.
+It also leaves room to add `lights`, `mqtt`, and `serial` later without reshaping the local model.
+
+## YAML Rules
+
+The loader should enforce these rules.
+
+1. `inputs[*].id`, `relays[*].id`, and `covers[*].id` must be unique within their section.
+2. `device` values must use the existing sysfs naming style such as `di_2_15` and `ro_3_14`.
+3. `covers[*].up_relay` and `covers[*].down_relay` must reference existing relay ids.
+4. `covers[*].up_relay` and `covers[*].down_relay` must not be the same relay.
+5. `bindings[*].input` must reference an existing input id.
+6. `bindings[*].target` must reference an existing entity id.
+7. `bindings[*].action` should initially allow only `toggle`, `open`, `close`, and `stop`.
+8. `max_time` must be a positive duration.
+
+The loader should fail fast with explicit field-level errors.
+Unknown YAML fields should also fail validation so configuration drift is caught early.
+
+## Proposed Go Types
+
+These types should live in a new `internal/config` package.
+
+```go
+package config
+
+import "time"
+
+type File struct {
+	Sysfs    SysfsConfig     `yaml:"sysfs"`
+	Inputs   []InputConfig   `yaml:"inputs"`
+	Relays   []RelayConfig   `yaml:"relays"`
+	Covers   []CoverConfig   `yaml:"covers"`
+	Bindings []BindingConfig `yaml:"bindings"`
+}
+
+type SysfsConfig struct {
+	Root string `yaml:"root"`
+}
+
+type InputConfig struct {
+	ID     string `yaml:"id"`
+	Name   string `yaml:"name"`
+	Device string `yaml:"device"`
+}
+
+type RelayConfig struct {
+	ID     string `yaml:"id"`
+	Name   string `yaml:"name"`
+	Device string `yaml:"device"`
+}
+
+type CoverConfig struct {
+	ID        string        `yaml:"id"`
+	Name      string        `yaml:"name"`
+	UpRelay   string        `yaml:"up_relay"`
+	DownRelay string        `yaml:"down_relay"`
+	MaxTime   time.Duration `yaml:"max_time"`
+}
+
+type BindingConfig struct {
+	Input  string `yaml:"input"`
+	Target string `yaml:"target"`
+	Action string `yaml:"action"`
+}
+```
+
+The first loader API can stay small.
+
+```go
+func Load(path string) (*File, error)
+func (f *File) Validate() error
+```
+
+## Runtime Model
+
+Phase 2 should also introduce simple runtime structs for resolved local entities.
+These do not need to know anything about YAML tags.
+
+```go
+package domain
+
+import "time"
+
+type Input struct {
+	ID     string
+	Name   string
+	Device string
+}
+
+type Relay struct {
+	ID     string
+	Name   string
+	Device string
+}
+
+type Cover struct {
+	ID        string
+	Name      string
+	UpRelay   Relay
+	DownRelay Relay
+	MaxTime   time.Duration
+}
+
+type Binding struct {
+	InputID  string
+	TargetID string
+	Action   string
+}
+```
+
+The important part is not the exact package name.
+The important part is separating parsed config from resolved runtime objects.
+
+## CLI Proposal
+
+The hardcoded fixture root in `cmd/nest/main.go` should be replaced by a config path.
+
+The minimal contract should be:
+
+```text
+nest run --config /etc/nest/config.yaml
+nest validate --config ./config.yaml
+```
+
+`run` should load config, validate it, and start the controller.
+`validate` should load config, validate it, and exit without touching hardware.
+
+If we want to keep the first CLI even smaller, we can skip subcommands and support only:
+
+```text
+nest --config ./config.yaml
+```
+
+That is acceptable for Phase 2.
+Adding `validate` early is still useful because it gives a clean way to test config changes without running the controller.
+
+## Package Boundaries
+
+This is the smallest package split that seems worth introducing now.
+
+1. `internal/config`
+Reads YAML and validates config.
+2. `internal/domain`
+Holds resolved local entities and bindings.
+3. `internal/sysfs`
+Continues to own device discovery and low-level reads and writes.
+4. `cmd/nest`
+Owns CLI parsing and process wiring.
+
+Phase 2 does not need a dedicated controller package yet unless the first cover control code clearly needs it.
+
+## Validation Details
+
+The loader should use `yaml.Decoder.KnownFields(true)` so misspelled fields are rejected.
+
+Validation errors should include enough context to fix the file quickly.
+Examples:
+
+1. `covers[0].up_relay: unknown relay id "office-up"`
+2. `bindings[0].action: unsupported action "press"`
+3. `relays[1].device: invalid relay device "di_2_03"`
+
+This will matter once the config gets larger and moves out of the repository.
+
+## Suggested Delivery Order
+
+Implement Phase 2 in this order.
+
+1. Add `internal/config` with file structs and `Load`.
+2. Add validation and table-driven tests.
+3. Add resolved runtime structs and a small conversion step from config to runtime.
+4. Replace the hardcoded path in `cmd/nest/main.go` with a config-driven path.
+5. Add a sample local cover config under `test/fixtures` or `docs`.
+
+## Explicit Non-Goals
+
+These should wait until later phases.
+
+1. MQTT settings.
+2. Serial or Modbus settings.
+3. Multi-unit light mappings.
+4. Debounce or press semantics beyond a simple action string.
+5. Position tracking or restart recovery.
+
+## Recommendation
+
+Build Phase 2 around a local-only YAML file with `inputs`, `relays`, `covers`, and `bindings`.
+Keep transport out of the file for now.
+Add one config loader, one validator, and one config-driven CLI path.
+
+That gives Phase 3 a stable base for implementing single-unit cover control without dragging in unrelated design decisions.

--- a/docs/phase-2-proposal.md
+++ b/docs/phase-2-proposal.md
@@ -3,9 +3,9 @@
 ## Goal
 
 Phase 2 should introduce the smallest config model that lets `nest` describe one local unit.
-That model should be enough to wire local inputs, relays, and a first cover entity without pulling in MQTT or Modbus concerns.
+That model should be enough to define local digital inputs, push buttons, and relays without pulling in MQTT, Modbus, or cover control yet.
 
-This keeps the next phase focused on cover behavior rather than config redesign.
+This keeps the next phase focused on local input semantics rather than config redesign.
 
 ## Scope
 
@@ -13,73 +13,62 @@ Phase 2 should deliver four concrete things.
 
 1. A YAML file format for one unit.
 2. A loader that reads and validates that file.
-3. Internal types that represent local inputs, relays, and covers.
+3. Internal types that represent local digital inputs, push buttons, and relays.
 4. A CLI entrypoint that accepts a config path instead of hardcoding fixture paths.
 
-Phase 2 should not include transport config, Home Assistant integration, or distributed mappings.
+Phase 2 should not include transport config, Home Assistant integration, distributed mappings, motors, or covers.
 
 ## Proposed Config Shape
 
 This proposal keeps the file local-only.
-It borrows the cover example from `docs/design.md`, but makes identifiers explicit so later phases can reference entities without depending on display names.
+It makes hardware and semantic input devices explicit, but stops before bindings and cover entities.
 
 ```yaml
 sysfs:
-  root: /
+  root: test/fixtures
 
-inputs:
-  - id: office-shade-button
-    name: Office shade toggle
-    device: di_2_15
+digital_inputs:
+  - id: office_button_input
+    device: di_3_16
+
+push_buttons:
+  - id: office_button
+    name: Office shade button
+    input: office_button_input
 
 relays:
-  - id: office-shade-up
+  - id: office_shade_up
     name: Office shade up
     device: ro_3_14
-  - id: office-shade-down
+  - id: office_shade_down
     name: Office shade down
     device: ro_3_13
-
-covers:
-  - id: office
-    name: Office shade
-    up_relay: office-shade-up
-    down_relay: office-shade-down
-    max_time: 30s
-
-bindings:
-  - input: office-shade-button
-    target: office
-    action: toggle
 ```
 
 ## Why This Shape
 
 This shape keeps hardware details at the edges.
-Inputs and relays map directly to sysfs device identifiers.
-Entities such as covers reference relay ids rather than raw sysfs names.
+`digital_inputs` and `relays` map directly to sysfs device identifiers.
+`push_buttons` are semantic devices layered on top of raw digital inputs.
 
 That gives us a clear separation.
 
-1. Hardware inventory: `inputs` and `relays`.
-2. Local domain entities: `covers`.
-3. Behavior wiring: `bindings`.
+1. Hardware inventory: `digital_inputs` and `relays`.
+2. Semantic local devices: `push_buttons`.
+3. Later behavior wiring: `bindings`.
 
-This is enough for the single-unit shade slice described in the implementation plan.
-It also leaves room to add `lights`, `mqtt`, and `serial` later without reshaping the local model.
+This is enough for the next local input slice.
+It also leaves room to add `bindings`, `motors`, `covers`, `mqtt`, and `serial` later without reshaping the low-level model.
 
 ## YAML Rules
 
 The loader should enforce these rules.
 
-1. `inputs[*].id`, `relays[*].id`, and `covers[*].id` must be unique within their section.
+1. `digital_inputs[*].id`, `push_buttons[*].id`, and `relays[*].id` must be unique within their section.
 2. `device` values must use the existing sysfs naming style such as `di_2_15` and `ro_3_14`.
-3. `covers[*].up_relay` and `covers[*].down_relay` must reference existing relay ids.
-4. `covers[*].up_relay` and `covers[*].down_relay` must not be the same relay.
-5. `bindings[*].input` must reference an existing input id.
-6. `bindings[*].target` must reference an existing entity id.
-7. `bindings[*].action` should initially allow only `toggle`, `open`, `close`, and `stop`.
-8. `max_time` must be a positive duration.
+3. `digital_inputs[*].device` must match a digital input identifier.
+4. `relays[*].device` must match a relay identifier.
+5. `push_buttons[*].input` must reference an existing digital input id.
 
 The loader should fail fast with explicit field-level errors.
 Unknown YAML fields should also fail validation so configuration drift is caught early.
@@ -95,20 +84,24 @@ import "time"
 
 type File struct {
 	Sysfs    SysfsConfig     `yaml:"sysfs"`
-	Inputs   []InputConfig   `yaml:"inputs"`
-	Relays   []RelayConfig   `yaml:"relays"`
-	Covers   []CoverConfig   `yaml:"covers"`
-	Bindings []BindingConfig `yaml:"bindings"`
+	DigitalInputs []DigitalInputConfig `yaml:"digital_inputs"`
+	PushButtons   []PushButtonConfig   `yaml:"push_buttons"`
+	Relays        []RelayConfig        `yaml:"relays"`
 }
 
 type SysfsConfig struct {
 	Root string `yaml:"root"`
 }
 
-type InputConfig struct {
+type DigitalInputConfig struct {
 	ID     string `yaml:"id"`
-	Name   string `yaml:"name"`
 	Device string `yaml:"device"`
+}
+
+type PushButtonConfig struct {
+	ID    string `yaml:"id"`
+	Name  string `yaml:"name"`
+	Input string `yaml:"input"`
 }
 
 type RelayConfig struct {
@@ -116,68 +109,79 @@ type RelayConfig struct {
 	Name   string `yaml:"name"`
 	Device string `yaml:"device"`
 }
-
-type CoverConfig struct {
-	ID        string        `yaml:"id"`
-	Name      string        `yaml:"name"`
-	UpRelay   string        `yaml:"up_relay"`
-	DownRelay string        `yaml:"down_relay"`
-	MaxTime   time.Duration `yaml:"max_time"`
-}
-
-type BindingConfig struct {
-	Input  string `yaml:"input"`
-	Target string `yaml:"target"`
-	Action string `yaml:"action"`
-}
 ```
 
 The first loader API can stay small.
 
 ```go
 func Load(path string) (*File, error)
-func (f *File) Validate() error
+func Validate(f *File) error
 ```
 
 ## Runtime Model
 
-Phase 2 should also introduce simple runtime structs for resolved local entities.
+Phase 2 should keep runtime data procedural and explicit.
+That means startup-built lookup maps rather than an object graph of linked structs.
+
 These do not need to know anything about YAML tags.
 
 ```go
-package domain
-
-import "time"
-
-type Input struct {
-	ID     string
-	Name   string
-	Device string
-}
-
-type Relay struct {
-	ID     string
-	Name   string
-	Device string
-}
-
-type Cover struct {
-	ID        string
-	Name      string
-	UpRelay   Relay
-	DownRelay Relay
-	MaxTime   time.Duration
-}
-
-type Binding struct {
-	InputID  string
-	TargetID string
-	Action   string
+type Runtime struct {
+	DigitalInputsByDevice map[string]config.DigitalInputConfig
+	ButtonsByInputID      map[string][]config.PushButtonConfig
 }
 ```
 
 The important part is not the exact package name.
-The important part is separating parsed config from resolved runtime objects.
+The important part is separating parsed config from runtime indexes.
+The program should build those indexes at startup and keep them for the entire process lifetime.
+
+## Event Pipeline
+
+The next layer after config should be a shared in-process event bus.
+The bus should carry a single top-level event type with one payload per event kind.
+That gives `nest` one event stream while keeping event payloads explicit.
+
+```go
+type EventKind string
+
+const (
+	EventDigitalInput EventKind = "digital_input"
+	EventPushButton   EventKind = "push_button"
+)
+
+type Event struct {
+	Kind         EventKind
+	DigitalInput *DigitalInputEvent
+	PushButton   *PushButtonEvent
+}
+
+type DigitalInputEvent struct {
+	InputID   string
+	DeviceID  string
+	IsRising  bool
+	IsFalling bool
+}
+
+type PushButtonEvent struct {
+	ButtonID string
+	Name     string
+	Kind     string
+}
+```
+
+This is a tagged-union style event envelope.
+It fits Go well and keeps the dispatch logic explicit.
+
+The expected flow is:
+
+1. `sysfs` polling emits `DigitalInputEvent` values.
+2. An input mapper resolves those to configured `push_buttons`.
+3. The mapper emits `PushButtonEvent` values on the same shared event bus.
+4. A later automation handler consumes `PushButtonEvent` values and maps them to bindings.
+
+For the first cut, `PushButtonEvent.Kind` only needs `pressed`.
+Later phases can add `released`, `long_press`, and similar higher-level semantics.
 
 ## CLI Proposal
 
@@ -208,14 +212,16 @@ This is the smallest package split that seems worth introducing now.
 
 1. `internal/config`
 Reads YAML and validates config.
-2. `internal/domain`
-Holds resolved local entities and bindings.
+2. `internal/runtime`
+Builds startup lookup maps from config.
 3. `internal/sysfs`
 Continues to own device discovery and low-level reads and writes.
+4. `internal/event`
+Defines shared event types and the in-process event bus.
 4. `cmd/nest`
 Owns CLI parsing and process wiring.
 
-Phase 2 does not need a dedicated controller package yet unless the first cover control code clearly needs it.
+Phase 2 does not need a dedicated controller package yet unless the first automation code clearly needs it.
 
 ## Validation Details
 
@@ -224,8 +230,8 @@ The loader should use `yaml.Decoder.KnownFields(true)` so misspelled fields are 
 Validation errors should include enough context to fix the file quickly.
 Examples:
 
-1. `covers[0].up_relay: unknown relay id "office-up"`
-2. `bindings[0].action: unsupported action "press"`
+1. `push_buttons[0].input: unknown digital input "office_button_input"`
+2. `digital_inputs[0].device: invalid digital input device "ro_3_14"`
 3. `relays[1].device: invalid relay device "di_2_03"`
 
 This will matter once the config gets larger and moves out of the repository.
@@ -236,9 +242,10 @@ Implement Phase 2 in this order.
 
 1. Add `internal/config` with file structs and `Load`.
 2. Add validation and table-driven tests.
-3. Add resolved runtime structs and a small conversion step from config to runtime.
+3. Add startup-built runtime indexes.
 4. Replace the hardcoded path in `cmd/nest/main.go` with a config-driven path.
-5. Add a sample local cover config under `test/fixtures` or `docs`.
+5. Add a sample local config under `test/fixtures` or `docs`.
+6. Add a shared event bus and map `DigitalInputEvent` to `PushButtonEvent`.
 
 ## Explicit Non-Goals
 
@@ -247,13 +254,14 @@ These should wait until later phases.
 1. MQTT settings.
 2. Serial or Modbus settings.
 3. Multi-unit light mappings.
-4. Debounce or press semantics beyond a simple action string.
-5. Position tracking or restart recovery.
+4. Bindings and automation rules.
+5. Motors and covers.
+6. Position tracking or restart recovery.
 
 ## Recommendation
 
-Build Phase 2 around a local-only YAML file with `inputs`, `relays`, `covers`, and `bindings`.
-Keep transport out of the file for now.
-Add one config loader, one validator, and one config-driven CLI path.
+Build Phase 2 around a local-only YAML file with `digital_inputs`, `push_buttons`, and `relays`.
+Keep transport, bindings, and covers out of the file for now.
+Add one config loader, one validator, startup lookup maps, and a shared tagged-union event bus.
 
-That gives Phase 3 a stable base for implementing single-unit cover control without dragging in unrelated design decisions.
+That gives the next phase a stable base for implementing input semantics and later automation without dragging in unrelated cover design decisions.

--- a/docs/phase-2-proposal.md
+++ b/docs/phase-2-proposal.md
@@ -82,7 +82,7 @@ package config
 
 import "time"
 
-type File struct {
+type Root struct {
 	Sysfs    SysfsConfig     `yaml:"sysfs"`
 	DigitalInputs []DigitalInputConfig `yaml:"digital_inputs"`
 	PushButtons   []PushButtonConfig   `yaml:"push_buttons"`
@@ -114,8 +114,8 @@ type RelayConfig struct {
 The first loader API can stay small.
 
 ```go
-func Load(path string) (*File, error)
-func Validate(f *File) error
+func Load(path string) (*Root, error)
+func Validate(f *Root) error
 ```
 
 ## Runtime Model

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ var (
 	relayPattern         = regexp.MustCompile(`^ro_\d+_\d+$`)
 )
 
-type File struct {
+type Root struct {
 	Sysfs         SysfsConfig          `yaml:"sysfs"`
 	DigitalInputs []DigitalInputConfig `yaml:"digital_inputs"`
 	PushButtons   []PushButtonConfig   `yaml:"push_buttons"`
@@ -45,7 +45,7 @@ type RelayConfig struct {
 	Device string `yaml:"device"`
 }
 
-func Load(path string) (*File, error) {
+func Load(path string) (*Root, error) {
 	if path == "" {
 		return nil, errMissingConfigPath
 	}
@@ -55,7 +55,7 @@ func Load(path string) (*File, error) {
 		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
 
-	var file File
+	var file Root
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&file); err != nil {
@@ -69,7 +69,7 @@ func Load(path string) (*File, error) {
 	return &file, nil
 }
 
-func Validate(f *File) error {
+func Validate(f *Root) error {
 	var errs error
 
 	if strings.TrimSpace(f.Sysfs.Root) == "" {
@@ -116,7 +116,7 @@ func Validate(f *File) error {
 	return errs
 }
 
-func DeviceIDs(f *File) []string {
+func DeviceIDs(f *Root) []string {
 	deviceIDs := make([]string, 0, len(f.DigitalInputs)+len(f.Relays))
 	for _, input := range f.DigitalInputs {
 		deviceIDs = append(deviceIDs, input.Device)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,19 @@ func Load(path string) (*Root, error) {
 		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
 
+	file, err := decodeRoot(path, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := Validate(file); err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func decodeRoot(path string, data []byte) (*Root, error) {
 	var file Root
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
@@ -70,10 +83,6 @@ func Load(path string) (*Root, error) {
 		}
 
 		return nil, fmt.Errorf("decode config %s: multiple YAML documents are not supported", path)
-	}
-
-	if err := Validate(&file); err != nil {
-		return nil, err
 	}
 
 	return &file, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -71,49 +70,50 @@ func Load(path string) (*File, error) {
 }
 
 func Validate(f *File) error {
-	var errs []string
+	var errs error
 
 	if strings.TrimSpace(f.Sysfs.Root) == "" {
-		errs = append(errs, "sysfs.root: required")
+		errs = errors.Join(errs, fmt.Errorf("sysfs.root: required"))
 	}
 
 	inputIDs := make(map[string]struct{}, len(f.DigitalInputs))
 	for i, input := range f.DigitalInputs {
 		prefix := fmt.Sprintf("digital_inputs[%d]", i)
-		validateID(prefix+".id", input.ID, inputIDs, &errs)
-		validateDevice(prefix+".device", input.Device, digitalInputPattern, "digital input", &errs)
+		errs = errors.Join(
+			errs,
+			validateID(prefix+".id", input.ID, inputIDs),
+			validateDevice(prefix+".device", input.Device, digitalInputPattern, "digital input"),
+		)
 	}
 
 	buttonIDs := make(map[string]struct{}, len(f.PushButtons))
 	for i, button := range f.PushButtons {
 		prefix := fmt.Sprintf("push_buttons[%d]", i)
-		validateID(prefix+".id", button.ID, buttonIDs, &errs)
+		errs = errors.Join(errs, validateID(prefix+".id", button.ID, buttonIDs))
 		if strings.TrimSpace(button.Name) == "" {
-			errs = append(errs, prefix+".name: required")
+			errs = errors.Join(errs, fmt.Errorf("%s.name: required", prefix))
 		}
 		if strings.TrimSpace(button.Input) == "" {
-			errs = append(errs, prefix+".input: required")
+			errs = errors.Join(errs, fmt.Errorf("%s.input: required", prefix))
 		} else if _, ok := inputIDs[button.Input]; !ok {
-			errs = append(errs, fmt.Sprintf("%s.input: unknown digital input %q", prefix, button.Input))
+			errs = errors.Join(errs, fmt.Errorf("%s.input: unknown digital input %q", prefix, button.Input))
 		}
 	}
 
 	relayIDs := make(map[string]struct{}, len(f.Relays))
 	for i, relay := range f.Relays {
 		prefix := fmt.Sprintf("relays[%d]", i)
-		validateID(prefix+".id", relay.ID, relayIDs, &errs)
+		errs = errors.Join(
+			errs,
+			validateID(prefix+".id", relay.ID, relayIDs),
+			validateDevice(prefix+".device", relay.Device, relayPattern, "relay"),
+		)
 		if strings.TrimSpace(relay.Name) == "" {
-			errs = append(errs, prefix+".name: required")
+			errs = errors.Join(errs, fmt.Errorf("%s.name: required", prefix))
 		}
-		validateDevice(prefix+".device", relay.Device, relayPattern, "relay", &errs)
 	}
 
-	if len(errs) == 0 {
-		return nil
-	}
-
-	sort.Strings(errs)
-	return errors.New(strings.Join(errs, "; "))
+	return errs
 }
 
 func DeviceIDs(f *File) []string {
@@ -128,29 +128,29 @@ func DeviceIDs(f *File) []string {
 	return deviceIDs
 }
 
-func validateID(field string, value string, seen map[string]struct{}, errs *[]string) {
+func validateID(field string, value string, seen map[string]struct{}) error {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		*errs = append(*errs, field+": required")
-		return
+		return fmt.Errorf("%s: required", field)
 	}
 
 	if _, ok := seen[value]; ok {
-		*errs = append(*errs, fmt.Sprintf("%s: duplicate id %q", field, value))
-		return
+		return fmt.Errorf("%s: duplicate id %q", field, value)
 	}
 
 	seen[value] = struct{}{}
+	return nil
 }
 
-func validateDevice(field string, value string, pattern *regexp.Regexp, kind string, errs *[]string) {
+func validateDevice(field string, value string, pattern *regexp.Regexp, kind string) error {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		*errs = append(*errs, field+": required")
-		return
+		return fmt.Errorf("%s: required", field)
 	}
 
 	if !pattern.MatchString(value) {
-		*errs = append(*errs, fmt.Sprintf("%s: invalid %s device %q", field, kind, value))
+		return fmt.Errorf("%s: invalid %s device %q", field, kind, value)
 	}
+
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	errMissingConfigPath = errors.New("missing config path")
+	digitalInputPattern  = regexp.MustCompile(`^di_\d+_\d+$`)
+	relayPattern         = regexp.MustCompile(`^ro_\d+_\d+$`)
+)
+
+type File struct {
+	Sysfs         SysfsConfig          `yaml:"sysfs"`
+	DigitalInputs []DigitalInputConfig `yaml:"digital_inputs"`
+	PushButtons   []PushButtonConfig   `yaml:"push_buttons"`
+	Relays        []RelayConfig        `yaml:"relays"`
+}
+
+type SysfsConfig struct {
+	Root string `yaml:"root"`
+}
+
+type DigitalInputConfig struct {
+	ID     string `yaml:"id"`
+	Device string `yaml:"device"`
+}
+
+type PushButtonConfig struct {
+	ID    string `yaml:"id"`
+	Name  string `yaml:"name"`
+	Input string `yaml:"input"`
+}
+
+type RelayConfig struct {
+	ID     string `yaml:"id"`
+	Name   string `yaml:"name"`
+	Device string `yaml:"device"`
+}
+
+func Load(path string) (*File, error) {
+	if path == "" {
+		return nil, errMissingConfigPath
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+
+	var file File
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&file); err != nil {
+		return nil, fmt.Errorf("decode config %s: %w", path, err)
+	}
+
+	if err := Validate(&file); err != nil {
+		return nil, err
+	}
+
+	return &file, nil
+}
+
+func Validate(f *File) error {
+	var errs []string
+
+	if strings.TrimSpace(f.Sysfs.Root) == "" {
+		errs = append(errs, "sysfs.root: required")
+	}
+
+	inputIDs := make(map[string]struct{}, len(f.DigitalInputs))
+	for i, input := range f.DigitalInputs {
+		prefix := fmt.Sprintf("digital_inputs[%d]", i)
+		validateID(prefix+".id", input.ID, inputIDs, &errs)
+		validateDevice(prefix+".device", input.Device, digitalInputPattern, "digital input", &errs)
+	}
+
+	buttonIDs := make(map[string]struct{}, len(f.PushButtons))
+	for i, button := range f.PushButtons {
+		prefix := fmt.Sprintf("push_buttons[%d]", i)
+		validateID(prefix+".id", button.ID, buttonIDs, &errs)
+		if strings.TrimSpace(button.Name) == "" {
+			errs = append(errs, prefix+".name: required")
+		}
+		if strings.TrimSpace(button.Input) == "" {
+			errs = append(errs, prefix+".input: required")
+		} else if _, ok := inputIDs[button.Input]; !ok {
+			errs = append(errs, fmt.Sprintf("%s.input: unknown digital input %q", prefix, button.Input))
+		}
+	}
+
+	relayIDs := make(map[string]struct{}, len(f.Relays))
+	for i, relay := range f.Relays {
+		prefix := fmt.Sprintf("relays[%d]", i)
+		validateID(prefix+".id", relay.ID, relayIDs, &errs)
+		if strings.TrimSpace(relay.Name) == "" {
+			errs = append(errs, prefix+".name: required")
+		}
+		validateDevice(prefix+".device", relay.Device, relayPattern, "relay", &errs)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	sort.Strings(errs)
+	return errors.New(strings.Join(errs, "; "))
+}
+
+func DeviceIDs(f *File) []string {
+	deviceIDs := make([]string, 0, len(f.DigitalInputs)+len(f.Relays))
+	for _, input := range f.DigitalInputs {
+		deviceIDs = append(deviceIDs, input.Device)
+	}
+	for _, relay := range f.Relays {
+		deviceIDs = append(deviceIDs, relay.Device)
+	}
+
+	return deviceIDs
+}
+
+func validateID(field string, value string, seen map[string]struct{}, errs *[]string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		*errs = append(*errs, field+": required")
+		return
+	}
+
+	if _, ok := seen[value]; ok {
+		*errs = append(*errs, fmt.Sprintf("%s: duplicate id %q", field, value))
+		return
+	}
+
+	seen[value] = struct{}{}
+}
+
+func validateDevice(field string, value string, pattern *regexp.Regexp, kind string, errs *[]string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		*errs = append(*errs, field+": required")
+		return
+	}
+
+	if !pattern.MatchString(value) {
+		*errs = append(*errs, fmt.Sprintf("%s: invalid %s device %q", field, kind, value))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -62,6 +63,15 @@ func Load(path string) (*Root, error) {
 		return nil, fmt.Errorf("decode config %s: %w", path, err)
 	}
 
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return nil, fmt.Errorf("decode trailing config %s: %w", path, err)
+		}
+
+		return nil, fmt.Errorf("decode config %s: multiple YAML documents are not supported", path)
+	}
+
 	if err := Validate(&file); err != nil {
 		return nil, err
 	}
@@ -72,46 +82,70 @@ func Load(path string) (*Root, error) {
 func Validate(f *Root) error {
 	var errs error
 
-	if strings.TrimSpace(f.Sysfs.Root) == "" {
-		errs = errors.Join(errs, fmt.Errorf("sysfs.root: required"))
+	errs = errors.Join(errs, validateRequiredField("sysfs.root", f.Sysfs.Root))
+
+	if len(f.DigitalInputs) == 0 && len(f.Relays) == 0 {
+		errs = errors.Join(errs, fmt.Errorf("at least one digital_input or relay is required"))
 	}
 
-	inputIDs := make(map[string]struct{}, len(f.DigitalInputs))
+	inputIDs := make([]string, 0, len(f.DigitalInputs))
+	inputDevices := make([]string, 0, len(f.DigitalInputs))
 	for i, input := range f.DigitalInputs {
 		prefix := fmt.Sprintf("digital_inputs[%d]", i)
 		errs = errors.Join(
 			errs,
-			validateID(prefix+".id", input.ID, inputIDs),
+			validateID(prefix+".id", input.ID),
 			validateDevice(prefix+".device", input.Device, digitalInputPattern, "digital input"),
 		)
+		inputIDs = append(inputIDs, input.ID)
+		inputDevices = append(inputDevices, input.Device)
+	}
+	errs = errors.Join(
+		errs,
+		validateUniqueValues("digital_inputs", "id", "id", inputIDs),
+		validateUniqueValues("digital_inputs", "device", "digital input device", inputDevices),
+	)
+
+	knownInputIDs := make(map[string]struct{}, len(inputIDs))
+	for _, inputID := range inputIDs {
+		knownInputIDs[inputID] = struct{}{}
 	}
 
-	buttonIDs := make(map[string]struct{}, len(f.PushButtons))
+	buttonIDs := make([]string, 0, len(f.PushButtons))
 	for i, button := range f.PushButtons {
 		prefix := fmt.Sprintf("push_buttons[%d]", i)
-		errs = errors.Join(errs, validateID(prefix+".id", button.ID, buttonIDs))
-		if strings.TrimSpace(button.Name) == "" {
-			errs = errors.Join(errs, fmt.Errorf("%s.name: required", prefix))
-		}
-		if strings.TrimSpace(button.Input) == "" {
-			errs = errors.Join(errs, fmt.Errorf("%s.input: required", prefix))
-		} else if _, ok := inputIDs[button.Input]; !ok {
+		errs = errors.Join(
+			errs,
+			validateID(prefix+".id", button.ID),
+			validateRequiredField(prefix+".name", button.Name),
+		)
+		if err := validateRequiredField(prefix+".input", button.Input); err != nil {
+			errs = errors.Join(errs, err)
+		} else if _, ok := knownInputIDs[button.Input]; !ok {
 			errs = errors.Join(errs, fmt.Errorf("%s.input: unknown digital input %q", prefix, button.Input))
 		}
+		buttonIDs = append(buttonIDs, button.ID)
 	}
+	errs = errors.Join(errs, validateUniqueValues("push_buttons", "id", "id", buttonIDs))
 
-	relayIDs := make(map[string]struct{}, len(f.Relays))
+	relayIDs := make([]string, 0, len(f.Relays))
+	relayDevices := make([]string, 0, len(f.Relays))
 	for i, relay := range f.Relays {
 		prefix := fmt.Sprintf("relays[%d]", i)
 		errs = errors.Join(
 			errs,
-			validateID(prefix+".id", relay.ID, relayIDs),
+			validateID(prefix+".id", relay.ID),
 			validateDevice(prefix+".device", relay.Device, relayPattern, "relay"),
+			validateRequiredField(prefix+".name", relay.Name),
 		)
-		if strings.TrimSpace(relay.Name) == "" {
-			errs = errors.Join(errs, fmt.Errorf("%s.name: required", prefix))
-		}
+		relayIDs = append(relayIDs, relay.ID)
+		relayDevices = append(relayDevices, relay.Device)
 	}
+	errs = errors.Join(
+		errs,
+		validateUniqueValues("relays", "id", "id", relayIDs),
+		validateUniqueValues("relays", "device", "relay device", relayDevices),
+	)
 
 	return errs
 }
@@ -128,28 +162,61 @@ func DeviceIDs(f *Root) []string {
 	return deviceIDs
 }
 
-func validateID(field string, value string, seen map[string]struct{}) error {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return fmt.Errorf("%s: required", field)
+func validateID(field string, value string) error {
+	if err := validateRequiredField(field, value); err != nil {
+		return err
 	}
-
-	if _, ok := seen[value]; ok {
-		return fmt.Errorf("%s: duplicate id %q", field, value)
-	}
-
-	seen[value] = struct{}{}
 	return nil
 }
 
 func validateDevice(field string, value string, pattern *regexp.Regexp, kind string) error {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return fmt.Errorf("%s: required", field)
+	if err := validateRequiredField(field, value); err != nil {
+		return err
 	}
 
 	if !pattern.MatchString(value) {
 		return fmt.Errorf("%s: invalid %s device %q", field, kind, value)
+	}
+
+	return nil
+}
+
+func validateNoOuterWhitespace(field string, value string) error {
+	if strings.TrimSpace(value) != value {
+		return fmt.Errorf("%s: must not have leading or trailing whitespace", field)
+	}
+
+	return nil
+}
+
+func validateRequired(field string, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s: required", field)
+	}
+
+	return nil
+}
+
+func validateRequiredField(field string, value string) error {
+	if err := validateRequired(field, value); err != nil {
+		return err
+	}
+
+	return validateNoOuterWhitespace(field, value)
+}
+
+func validateUniqueValues(section string, field string, label string, values []string) error {
+	seen := make(map[string]int, len(values))
+	for i, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+
+		if _, ok := seen[value]; ok {
+			return fmt.Errorf("%s[%d].%s: duplicate %s %q", section, i, field, label, value)
+		}
+
+		seen[value] = i
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,15 +82,33 @@ func Load(path string) (*Root, error) {
 func Validate(f *Root) error {
 	var errs error
 
-	errs = errors.Join(errs, validateRequiredField("sysfs.root", f.Sysfs.Root))
+	knownInputIDs, inputErr := validateDigitalInputs(f.DigitalInputs)
 
 	if len(f.DigitalInputs) == 0 && len(f.Relays) == 0 {
 		errs = errors.Join(errs, fmt.Errorf("at least one digital_input or relay is required"))
 	}
 
-	inputIDs := make([]string, 0, len(f.DigitalInputs))
-	inputDevices := make([]string, 0, len(f.DigitalInputs))
-	for i, input := range f.DigitalInputs {
+	errs = errors.Join(
+		errs,
+		validateSysfs(f.Sysfs),
+		inputErr,
+		validatePushButtons(f.PushButtons, knownInputIDs),
+		validateRelays(f.Relays),
+	)
+
+	return errs
+}
+
+func validateSysfs(sysfs SysfsConfig) error {
+	return validateRequiredField("sysfs.root", sysfs.Root)
+}
+
+func validateDigitalInputs(inputs []DigitalInputConfig) (map[string]struct{}, error) {
+	var errs error
+
+	inputIDs := make([]string, 0, len(inputs))
+	inputDevices := make([]string, 0, len(inputs))
+	for i, input := range inputs {
 		prefix := fmt.Sprintf("digital_inputs[%d]", i)
 		errs = errors.Join(
 			errs,
@@ -100,6 +118,7 @@ func Validate(f *Root) error {
 		inputIDs = append(inputIDs, input.ID)
 		inputDevices = append(inputDevices, input.Device)
 	}
+
 	errs = errors.Join(
 		errs,
 		validateUniqueValues("digital_inputs", "id", "id", inputIDs),
@@ -111,26 +130,40 @@ func Validate(f *Root) error {
 		knownInputIDs[inputID] = struct{}{}
 	}
 
-	buttonIDs := make([]string, 0, len(f.PushButtons))
-	for i, button := range f.PushButtons {
+	return knownInputIDs, errs
+}
+
+func validatePushButtons(buttons []PushButtonConfig, knownInputIDs map[string]struct{}) error {
+	var errs error
+
+	buttonIDs := make([]string, 0, len(buttons))
+	for i, button := range buttons {
 		prefix := fmt.Sprintf("push_buttons[%d]", i)
+		var inputErr error
+		if err := validateRequiredField(prefix+".input", button.Input); err != nil {
+			inputErr = err
+		} else if _, ok := knownInputIDs[button.Input]; !ok {
+			inputErr = fmt.Errorf("%s.input: unknown digital input %q", prefix, button.Input)
+		}
+
 		errs = errors.Join(
 			errs,
 			validateID(prefix+".id", button.ID),
 			validateRequiredField(prefix+".name", button.Name),
+			inputErr,
 		)
-		if err := validateRequiredField(prefix+".input", button.Input); err != nil {
-			errs = errors.Join(errs, err)
-		} else if _, ok := knownInputIDs[button.Input]; !ok {
-			errs = errors.Join(errs, fmt.Errorf("%s.input: unknown digital input %q", prefix, button.Input))
-		}
 		buttonIDs = append(buttonIDs, button.ID)
 	}
-	errs = errors.Join(errs, validateUniqueValues("push_buttons", "id", "id", buttonIDs))
 
-	relayIDs := make([]string, 0, len(f.Relays))
-	relayDevices := make([]string, 0, len(f.Relays))
-	for i, relay := range f.Relays {
+	return errors.Join(errs, validateUniqueValues("push_buttons", "id", "id", buttonIDs))
+}
+
+func validateRelays(relays []RelayConfig) error {
+	var errs error
+
+	relayIDs := make([]string, 0, len(relays))
+	relayDevices := make([]string, 0, len(relays))
+	for i, relay := range relays {
 		prefix := fmt.Sprintf("relays[%d]", i)
 		errs = errors.Join(
 			errs,
@@ -141,13 +174,12 @@ func Validate(f *Root) error {
 		relayIDs = append(relayIDs, relay.ID)
 		relayDevices = append(relayDevices, relay.Device)
 	}
-	errs = errors.Join(
+
+	return errors.Join(
 		errs,
 		validateUniqueValues("relays", "id", "id", relayIDs),
 		validateUniqueValues("relays", "device", "relay device", relayDevices),
 	)
-
-	return errs
 }
 
 func DeviceIDs(f *Root) []string {
@@ -174,11 +206,7 @@ func validateDevice(field string, value string, pattern *regexp.Regexp, kind str
 		return err
 	}
 
-	if !pattern.MatchString(value) {
-		return fmt.Errorf("%s: invalid %s device %q", field, kind, value)
-	}
-
-	return nil
+	return validatePattern(field, value, pattern, fmt.Sprintf("invalid %s device", kind))
 }
 
 func validateNoOuterWhitespace(field string, value string) error {
@@ -203,6 +231,14 @@ func validateRequiredField(field string, value string) error {
 	}
 
 	return validateNoOuterWhitespace(field, value)
+}
+
+func validatePattern(field string, value string, pattern *regexp.Regexp, label string) error {
+	if !pattern.MatchString(value) {
+		return fmt.Errorf("%s: %s %q", field, label, value)
+	}
+
+	return nil
 }
 
 func validateUniqueValues(section string, field string, label string, values []string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	path := filepath.Join("..", "..", "test", "fixtures", "config.local.yaml")
+
+	file, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test/fixtures", file.Sysfs.Root)
+	assert.Len(t, file.DigitalInputs, 1)
+	assert.Len(t, file.PushButtons, 1)
+	assert.Len(t, file.Relays, 2)
+	assert.Equal(t, []string{"di_3_16", "ro_3_14", "ro_3_13"}, DeviceIDs(file))
+}
+
+func TestLoadRejectsUnknownFields(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.yaml")
+	writeTestFile(t, path, "sysfs:\n  root: /tmp\nunknown: true\n")
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field unknown not found")
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    File
+		message string
+	}{
+		{
+			name:    "requires sysfs root",
+			file:    File{},
+			message: "sysfs.root: required",
+		},
+		{
+			name: "rejects duplicate digital input ids",
+			file: File{
+				Sysfs: SysfsConfig{Root: "/tmp"},
+				DigitalInputs: []DigitalInputConfig{
+					{ID: "button_input", Device: "di_3_16"},
+					{ID: "button_input", Device: "di_3_15"},
+				},
+			},
+			message: `digital_inputs[1].id: duplicate id "button_input"`,
+		},
+		{
+			name: "rejects invalid digital input devices",
+			file: File{
+				Sysfs:         SysfsConfig{Root: "/tmp"},
+				DigitalInputs: []DigitalInputConfig{{ID: "button_input", Device: "ro_3_14"}},
+			},
+			message: `digital_inputs[0].device: invalid digital input device "ro_3_14"`,
+		},
+		{
+			name: "requires buttons to reference known inputs",
+			file: File{
+				Sysfs:       SysfsConfig{Root: "/tmp"},
+				PushButtons: []PushButtonConfig{{ID: "button", Name: "Button", Input: "missing"}},
+			},
+			message: `push_buttons[0].input: unknown digital input "missing"`,
+		},
+		{
+			name: "rejects invalid relay devices",
+			file: File{
+				Sysfs:  SysfsConfig{Root: "/tmp"},
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "di_3_16"}},
+			},
+			message: `relays[0].device: invalid relay device "di_3_16"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(&tt.file)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.message)
+		})
+	}
+}
+
+func TestValidateAcceptsValidFile(t *testing.T) {
+	file := File{
+		Sysfs: SysfsConfig{Root: "/tmp"},
+		DigitalInputs: []DigitalInputConfig{
+			{ID: "office_button_input", Device: "di_3_16"},
+		},
+		PushButtons: []PushButtonConfig{
+			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
+		},
+		Relays: []RelayConfig{
+			{ID: "office_shade_up", Name: "Office shade up", Device: "ro_3_14"},
+			{ID: "office_shade_down", Name: "Office shade down", Device: "ro_3_13"},
+		},
+	}
+
+	require.NoError(t, Validate(&file))
+}
+
+func writeTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,17 +35,17 @@ func TestLoadRejectsUnknownFields(t *testing.T) {
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		file    File
+		file    Root
 		message string
 	}{
 		{
 			name:    "requires sysfs root",
-			file:    File{},
+			file:    Root{},
 			message: "sysfs.root: required",
 		},
 		{
 			name: "rejects duplicate digital input ids",
-			file: File{
+			file: Root{
 				Sysfs: SysfsConfig{Root: "/tmp"},
 				DigitalInputs: []DigitalInputConfig{
 					{ID: "button_input", Device: "di_3_16"},
@@ -56,7 +56,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "rejects invalid digital input devices",
-			file: File{
+			file: Root{
 				Sysfs:         SysfsConfig{Root: "/tmp"},
 				DigitalInputs: []DigitalInputConfig{{ID: "button_input", Device: "ro_3_14"}},
 			},
@@ -64,7 +64,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "requires buttons to reference known inputs",
-			file: File{
+			file: Root{
 				Sysfs:       SysfsConfig{Root: "/tmp"},
 				PushButtons: []PushButtonConfig{{ID: "button", Name: "Button", Input: "missing"}},
 			},
@@ -72,7 +72,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "rejects invalid relay devices",
-			file: File{
+			file: Root{
 				Sysfs:  SysfsConfig{Root: "/tmp"},
 				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "di_3_16"}},
 			},
@@ -90,7 +90,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestValidateAcceptsValidFile(t *testing.T) {
-	file := File{
+	file := Root{
 		Sysfs: SysfsConfig{Root: "/tmp"},
 		DigitalInputs: []DigitalInputConfig{
 			{ID: "office_button_input", Device: "di_3_16"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,6 +32,16 @@ func TestLoadRejectsUnknownFields(t *testing.T) {
 	assert.Contains(t, err.Error(), "field unknown not found")
 }
 
+func TestLoadRejectsTrailingYAMLDocuments(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.yaml")
+	writeTestFile(t, path, "sysfs:\n  root: /tmp\ndigital_inputs:\n  - id: button_input\n    device: di_3_16\n---\nextra: true\n")
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple YAML documents are not supported")
+}
+
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -44,6 +54,21 @@ func TestValidate(t *testing.T) {
 			message: "sysfs.root: required",
 		},
 		{
+			name: "rejects configs with no devices",
+			file: Root{
+				Sysfs: SysfsConfig{Root: "/tmp"},
+			},
+			message: "at least one digital_input or relay is required",
+		},
+		{
+			name: "rejects whitespace padded sysfs root",
+			file: Root{
+				Sysfs:  SysfsConfig{Root: " /tmp "},
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "ro_3_14"}},
+			},
+			message: "sysfs.root: must not have leading or trailing whitespace",
+		},
+		{
 			name: "rejects duplicate digital input ids",
 			file: Root{
 				Sysfs: SysfsConfig{Root: "/tmp"},
@@ -53,6 +78,17 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			message: `digital_inputs[1].id: duplicate id "button_input"`,
+		},
+		{
+			name: "rejects duplicate digital input devices",
+			file: Root{
+				Sysfs: SysfsConfig{Root: "/tmp"},
+				DigitalInputs: []DigitalInputConfig{
+					{ID: "button_input_1", Device: "di_3_16"},
+					{ID: "button_input_2", Device: "di_3_16"},
+				},
+			},
+			message: `digital_inputs[1].device: duplicate digital input device "di_3_16"`,
 		},
 		{
 			name: "rejects invalid digital input devices",
@@ -71,12 +107,49 @@ func TestValidate(t *testing.T) {
 			message: `push_buttons[0].input: unknown digital input "missing"`,
 		},
 		{
+			name: "rejects whitespace padded button ids",
+			file: Root{
+				Sysfs:         SysfsConfig{Root: "/tmp"},
+				DigitalInputs: []DigitalInputConfig{{ID: "button_input", Device: "di_3_16"}},
+				PushButtons:   []PushButtonConfig{{ID: " button ", Name: "Button", Input: "button_input"}},
+			},
+			message: "push_buttons[0].id: must not have leading or trailing whitespace",
+		},
+		{
+			name: "rejects whitespace padded button input references",
+			file: Root{
+				Sysfs:         SysfsConfig{Root: "/tmp"},
+				DigitalInputs: []DigitalInputConfig{{ID: "button_input", Device: "di_3_16"}},
+				PushButtons:   []PushButtonConfig{{ID: "button", Name: "Button", Input: " button_input "}},
+			},
+			message: "push_buttons[0].input: must not have leading or trailing whitespace",
+		},
+		{
 			name: "rejects invalid relay devices",
 			file: Root{
 				Sysfs:  SysfsConfig{Root: "/tmp"},
 				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "di_3_16"}},
 			},
 			message: `relays[0].device: invalid relay device "di_3_16"`,
+		},
+		{
+			name: "rejects duplicate relay devices",
+			file: Root{
+				Sysfs: SysfsConfig{Root: "/tmp"},
+				Relays: []RelayConfig{
+					{ID: "relay_1", Name: "Relay 1", Device: "ro_3_14"},
+					{ID: "relay_2", Name: "Relay 2", Device: "ro_3_14"},
+				},
+			},
+			message: `relays[1].device: duplicate relay device "ro_3_14"`,
+		},
+		{
+			name: "rejects whitespace padded relay devices",
+			file: Root{
+				Sysfs:  SysfsConfig{Root: "/tmp"},
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: " ro_3_14 "}},
+			},
+			message: "relays[0].device: must not have leading or trailing whitespace",
 		},
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/mhemeryck/nest/internal/event"
+	"github.com/mhemeryck/nest/internal/registry"
+	"github.com/mhemeryck/nest/internal/sysfs"
+)
+
+func Run(
+	index *registry.Index,
+	pollEvents <-chan sysfs.PollEvent,
+	sigCh <-chan os.Signal,
+) {
+	for {
+		select {
+		case <-sigCh:
+			return
+		case pollEvent, ok := <-pollEvents:
+			if !ok {
+				return
+			}
+
+			handlePollEvent(index, pollEvent)
+		}
+	}
+}
+
+func handlePollEvent(index *registry.Index, pollEvent sysfs.PollEvent) {
+	digitalInputEvent, ok := event.PollEventToDigitalInputEvent(index, pollEvent)
+	if ok {
+		handleEvent(index, digitalInputEvent)
+		return
+	}
+
+	slog.Info(
+		"poll event",
+		"identifier",
+		pollEvent.Device.Identifier,
+		"path",
+		pollEvent.Device.Path,
+		"old_value",
+		sysfs.PrintableValue(pollEvent.OldValue),
+		"new_value",
+		sysfs.PrintableValue(pollEvent.NewValue),
+		"rising",
+		pollEvent.IsRising,
+	)
+}
+
+func handleEvent(index *registry.Index, busEvent event.Event) {
+	switch busEvent.Kind {
+	case event.DigitalInputKind:
+		slog.Info(
+			"digital input event",
+			"input_id",
+			busEvent.DigitalInput.InputID,
+			"device_id",
+			busEvent.DigitalInput.DeviceID,
+			"rising",
+			busEvent.DigitalInput.IsRising,
+			"falling",
+			busEvent.DigitalInput.IsFalling,
+		)
+
+		for _, pushButtonEvent := range event.DigitalInputEventToPushButtonEvents(index, *busEvent.DigitalInput) {
+			handleEvent(index, pushButtonEvent)
+		}
+	case event.PushButtonKind:
+		slog.Info(
+			"push button event",
+			"button_id",
+			busEvent.PushButton.ButtonID,
+			"name",
+			busEvent.PushButton.Name,
+			"kind",
+			busEvent.PushButton.Kind,
+		)
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,109 @@
+package controller
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/registry"
+	"github.com/mhemeryck/nest/internal/sysfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunReturnsOnSignal(t *testing.T) {
+	index := registry.Build(&entity.Root{})
+	pollEvents := make(chan sysfs.PollEvent)
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+
+	go func() {
+		Run(index, pollEvents, sigCh)
+		close(done)
+	}()
+
+	sigCh <- os.Interrupt
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after signal")
+	}
+}
+
+func TestRunReturnsWhenPollEventsClose(t *testing.T) {
+	index := registry.Build(&entity.Root{})
+	pollEvents := make(chan sysfs.PollEvent)
+	sigCh := make(chan os.Signal)
+	done := make(chan struct{})
+
+	go func() {
+		Run(index, pollEvents, sigCh)
+		close(done)
+	}()
+
+	close(pollEvents)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after poll event channel closed")
+	}
+}
+
+func TestHandlePollEventLogsPushButtonEvent(t *testing.T) {
+	index := registry.Build(&entity.Root{
+		DigitalInputs: []entity.DigitalInput{{ID: entity.DigitalInputID("office_button_input"), Device: entity.DeviceID("di_3_16")}},
+		PushButtons:   []entity.PushButton{{ID: entity.PushButtonID("office_button"), Name: "Office button", Input: entity.DigitalInputID("office_button_input")}},
+	})
+
+	logs := captureLogs(t, func() {
+		handlePollEvent(index, sysfs.PollEvent{
+			Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
+			OldValue: sysfs.Off,
+			NewValue: sysfs.On,
+			IsRising: true,
+		})
+	})
+
+	assert.Contains(t, logs, "digital input event")
+	assert.Contains(t, logs, "push button event")
+	assert.Contains(t, logs, "office_button")
+}
+
+func TestHandlePollEventLogsRawPollEventForUnknownDevice(t *testing.T) {
+	index := registry.Build(&entity.Root{})
+
+	logs := captureLogs(t, func() {
+		handlePollEvent(index, sysfs.PollEvent{
+			Device:   sysfs.Device{Identifier: "ro_3_14", Path: "/sys/ro_3_14/ro_value"},
+			OldValue: sysfs.Off,
+			NewValue: sysfs.On,
+			IsRising: true,
+		})
+	})
+
+	assert.Contains(t, logs, "poll event")
+	assert.Contains(t, logs, "ro_3_14")
+	assert.NotContains(t, logs, "push button event")
+}
+
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	previous := slog.Default()
+	logger := slog.New(slog.NewTextHandler(&buffer, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	fn()
+
+	require.NotEmpty(t, buffer.String())
+	return buffer.String()
+}

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -1,0 +1,65 @@
+package entity
+
+import "github.com/mhemeryck/nest/internal/config"
+
+type Root struct {
+	SysfsRoot     string
+	DigitalInputs []DigitalInput
+	PushButtons   []PushButton
+	Relays        []Relay
+}
+
+type DigitalInput struct {
+	ID     string
+	Device string
+}
+
+type PushButton struct {
+	ID    string
+	Name  string
+	Input string
+}
+
+type Relay struct {
+	ID     string
+	Name   string
+	Device string
+}
+
+func FromConfig(root *config.Root) *Root {
+	if root == nil {
+		return nil
+	}
+
+	entities := &Root{
+		SysfsRoot:     root.Sysfs.Root,
+		DigitalInputs: make([]DigitalInput, 0, len(root.DigitalInputs)),
+		PushButtons:   make([]PushButton, 0, len(root.PushButtons)),
+		Relays:        make([]Relay, 0, len(root.Relays)),
+	}
+
+	for _, input := range root.DigitalInputs {
+		entities.DigitalInputs = append(entities.DigitalInputs, DigitalInput{
+			ID:     input.ID,
+			Device: input.Device,
+		})
+	}
+
+	for _, button := range root.PushButtons {
+		entities.PushButtons = append(entities.PushButtons, PushButton{
+			ID:    button.ID,
+			Name:  button.Name,
+			Input: button.Input,
+		})
+	}
+
+	for _, relay := range root.Relays {
+		entities.Relays = append(entities.Relays, Relay{
+			ID:     relay.ID,
+			Name:   relay.Name,
+			Device: relay.Device,
+		})
+	}
+
+	return entities
+}

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -2,6 +2,13 @@ package entity
 
 import "github.com/mhemeryck/nest/internal/config"
 
+type (
+	DeviceID       string
+	DigitalInputID string
+	PushButtonID   string
+	RelayID        string
+)
+
 type Root struct {
 	SysfsRoot     string
 	DigitalInputs []DigitalInput
@@ -10,20 +17,20 @@ type Root struct {
 }
 
 type DigitalInput struct {
-	ID     string
-	Device string
+	ID     DigitalInputID
+	Device DeviceID
 }
 
 type PushButton struct {
-	ID    string
+	ID    PushButtonID
 	Name  string
-	Input string
+	Input DigitalInputID
 }
 
 type Relay struct {
-	ID     string
+	ID     RelayID
 	Name   string
-	Device string
+	Device DeviceID
 }
 
 func FromConfig(root *config.Root) *Root {
@@ -40,24 +47,24 @@ func FromConfig(root *config.Root) *Root {
 
 	for _, input := range root.DigitalInputs {
 		entities.DigitalInputs = append(entities.DigitalInputs, DigitalInput{
-			ID:     input.ID,
-			Device: input.Device,
+			ID:     DigitalInputID(input.ID),
+			Device: DeviceID(input.Device),
 		})
 	}
 
 	for _, button := range root.PushButtons {
 		entities.PushButtons = append(entities.PushButtons, PushButton{
-			ID:    button.ID,
+			ID:    PushButtonID(button.ID),
 			Name:  button.Name,
-			Input: button.Input,
+			Input: DigitalInputID(button.Input),
 		})
 	}
 
 	for _, relay := range root.Relays {
 		entities.Relays = append(entities.Relays, Relay{
-			ID:     relay.ID,
+			ID:     RelayID(relay.ID),
 			Name:   relay.Name,
-			Device: relay.Device,
+			Device: DeviceID(relay.Device),
 		})
 	}
 

--- a/internal/entity/entity_test.go
+++ b/internal/entity/entity_test.go
@@ -1,0 +1,39 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromConfig(t *testing.T) {
+	root := FromConfig(&config.Root{
+		Sysfs: config.SysfsConfig{Root: "test/fixtures"},
+		DigitalInputs: []config.DigitalInputConfig{{
+			ID:     "office_button_input",
+			Device: "di_3_16",
+		}},
+		PushButtons: []config.PushButtonConfig{{
+			ID:    "office_button",
+			Name:  "Office button",
+			Input: "office_button_input",
+		}},
+		Relays: []config.RelayConfig{{
+			ID:     "office_shade_up",
+			Name:   "Office shade up",
+			Device: "ro_3_14",
+		}},
+	})
+
+	require.NotNil(t, root)
+	assert.Equal(t, "test/fixtures", root.SysfsRoot)
+	assert.Equal(t, []DigitalInput{{ID: "office_button_input", Device: "di_3_16"}}, root.DigitalInputs)
+	assert.Equal(t, []PushButton{{ID: "office_button", Name: "Office button", Input: "office_button_input"}}, root.PushButtons)
+	assert.Equal(t, []Relay{{ID: "office_shade_up", Name: "Office shade up", Device: "ro_3_14"}}, root.Relays)
+}
+
+func TestFromConfigNil(t *testing.T) {
+	assert.Nil(t, FromConfig(nil))
+}

--- a/internal/entity/entity_test.go
+++ b/internal/entity/entity_test.go
@@ -29,9 +29,9 @@ func TestFromConfig(t *testing.T) {
 
 	require.NotNil(t, root)
 	assert.Equal(t, "test/fixtures", root.SysfsRoot)
-	assert.Equal(t, []DigitalInput{{ID: "office_button_input", Device: "di_3_16"}}, root.DigitalInputs)
-	assert.Equal(t, []PushButton{{ID: "office_button", Name: "Office button", Input: "office_button_input"}}, root.PushButtons)
-	assert.Equal(t, []Relay{{ID: "office_shade_up", Name: "Office shade up", Device: "ro_3_14"}}, root.Relays)
+	assert.Equal(t, []DigitalInput{{ID: DigitalInputID("office_button_input"), Device: DeviceID("di_3_16")}}, root.DigitalInputs)
+	assert.Equal(t, []PushButton{{ID: PushButtonID("office_button"), Name: "Office button", Input: DigitalInputID("office_button_input")}}, root.PushButtons)
+	assert.Equal(t, []Relay{{ID: RelayID("office_shade_up"), Name: "Office shade up", Device: DeviceID("ro_3_14")}}, root.Relays)
 }
 
 func TestFromConfigNil(t *testing.T) {

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
@@ -21,14 +22,14 @@ type Event struct {
 }
 
 type DigitalInputEvent struct {
-	InputID   string
-	DeviceID  string
+	InputID   entity.DigitalInputID
+	DeviceID  entity.DeviceID
 	IsRising  bool
 	IsFalling bool
 }
 
 type PushButtonEvent struct {
-	ButtonID string
+	ButtonID entity.PushButtonID
 	Name     string
 	Kind     string
 }
@@ -38,7 +39,7 @@ func NewBus(buffer int) chan Event {
 }
 
 func PollEventToDigitalInputEvent(index *registry.Index, pollEvent sysfs.PollEvent) (Event, bool) {
-	input, ok := index.DigitalInputsByDevice[pollEvent.Device.Identifier]
+	input, ok := index.DigitalInputsByDevice[entity.DeviceID(pollEvent.Device.Identifier)]
 	if !ok {
 		return Event{}, false
 	}
@@ -47,7 +48,7 @@ func PollEventToDigitalInputEvent(index *registry.Index, pollEvent sysfs.PollEve
 		Kind: DigitalInputKind,
 		DigitalInput: &DigitalInputEvent{
 			InputID:   input.ID,
-			DeviceID:  pollEvent.Device.Identifier,
+			DeviceID:  entity.DeviceID(pollEvent.Device.Identifier),
 			IsRising:  pollEvent.IsRising,
 			IsFalling: pollEvent.OldValue == sysfs.On && pollEvent.NewValue == sysfs.Off,
 		},

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -34,10 +34,6 @@ type PushButtonEvent struct {
 	Kind     string
 }
 
-func NewBus(buffer int) chan Event {
-	return make(chan Event, buffer)
-}
-
 func PollEventToDigitalInputEvent(index *registry.Index, pollEvent sysfs.PollEvent) (Event, bool) {
 	input, ok := index.DigitalInputsByDevice[entity.DeviceID(pollEvent.Device.Identifier)]
 	if !ok {

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -1,0 +1,76 @@
+package event
+
+import (
+	"github.com/mhemeryck/nest/internal/registry"
+	"github.com/mhemeryck/nest/internal/sysfs"
+)
+
+type Kind string
+
+const (
+	DigitalInputKind Kind = "digital_input"
+	PushButtonKind   Kind = "push_button"
+
+	PushButtonPressed = "pressed"
+)
+
+type Event struct {
+	Kind         Kind
+	DigitalInput *DigitalInputEvent
+	PushButton   *PushButtonEvent
+}
+
+type DigitalInputEvent struct {
+	InputID   string
+	DeviceID  string
+	IsRising  bool
+	IsFalling bool
+}
+
+type PushButtonEvent struct {
+	ButtonID string
+	Name     string
+	Kind     string
+}
+
+func NewBus(buffer int) chan Event {
+	return make(chan Event, buffer)
+}
+
+func PollEventToDigitalInputEvent(index *registry.Index, pollEvent sysfs.PollEvent) (Event, bool) {
+	input, ok := index.DigitalInputsByDevice[pollEvent.Device.Identifier]
+	if !ok {
+		return Event{}, false
+	}
+
+	return Event{
+		Kind: DigitalInputKind,
+		DigitalInput: &DigitalInputEvent{
+			InputID:   input.ID,
+			DeviceID:  pollEvent.Device.Identifier,
+			IsRising:  pollEvent.IsRising,
+			IsFalling: pollEvent.OldValue == sysfs.On && pollEvent.NewValue == sysfs.Off,
+		},
+	}, true
+}
+
+func DigitalInputEventToPushButtonEvents(index *registry.Index, inputEvent DigitalInputEvent) []Event {
+	if !inputEvent.IsRising {
+		return nil
+	}
+
+	buttons := index.PushButtonsByInputID[inputEvent.InputID]
+	buttonEvents := make([]Event, 0, len(buttons))
+	for _, button := range buttons {
+		buttonEvents = append(buttonEvents, Event{
+			Kind: PushButtonKind,
+			PushButton: &PushButtonEvent{
+				ButtonID: button.ID,
+				Name:     button.Name,
+				Kind:     PushButtonPressed,
+			},
+		})
+	}
+
+	return buttonEvents
+}

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -3,7 +3,7 @@ package event
 import (
 	"testing"
 
-	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 	"github.com/stretchr/testify/assert"
@@ -11,8 +11,8 @@ import (
 )
 
 func TestPollEventToDigitalInputEvent(t *testing.T) {
-	index := registry.Build(&config.Root{
-		DigitalInputs: []config.DigitalInputConfig{{ID: "office_button_input", Device: "di_3_16"}},
+	index := registry.Build(&entity.Root{
+		DigitalInputs: []entity.DigitalInput{{ID: "office_button_input", Device: "di_3_16"}},
 	})
 
 	event, ok := PollEventToDigitalInputEvent(index, sysfs.PollEvent{
@@ -32,7 +32,7 @@ func TestPollEventToDigitalInputEvent(t *testing.T) {
 }
 
 func TestPollEventToDigitalInputEventIgnoresUnknownDevices(t *testing.T) {
-	index := registry.Build(&config.Root{})
+	index := registry.Build(&entity.Root{})
 
 	_, ok := PollEventToDigitalInputEvent(index, sysfs.PollEvent{
 		Device: sysfs.Device{Identifier: "ro_3_14"},
@@ -41,8 +41,8 @@ func TestPollEventToDigitalInputEventIgnoresUnknownDevices(t *testing.T) {
 }
 
 func TestDigitalInputEventToPushButtonEvents(t *testing.T) {
-	index := registry.Build(&config.Root{
-		PushButtons: []config.PushButtonConfig{
+	index := registry.Build(&entity.Root{
+		PushButtons: []entity.PushButton{
 			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
 			{ID: "office_button_secondary", Name: "Office button secondary", Input: "office_button_input"},
 		},
@@ -61,8 +61,8 @@ func TestDigitalInputEventToPushButtonEvents(t *testing.T) {
 }
 
 func TestDigitalInputEventToPushButtonEventsIgnoresFallingEdge(t *testing.T) {
-	index := registry.Build(&config.Root{
-		PushButtons: []config.PushButtonConfig{{ID: "office_button", Name: "Office button", Input: "office_button_input"}},
+	index := registry.Build(&entity.Root{
+		PushButtons: []entity.PushButton{{ID: "office_button", Name: "Office button", Input: "office_button_input"}},
 	})
 
 	events := DigitalInputEventToPushButtonEvents(index, DigitalInputEvent{

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPollEventToDigitalInputEvent(t *testing.T) {
-	index := registry.Build(&config.File{
+	index := registry.Build(&config.Root{
 		DigitalInputs: []config.DigitalInputConfig{{ID: "office_button_input", Device: "di_3_16"}},
 	})
 
@@ -32,7 +32,7 @@ func TestPollEventToDigitalInputEvent(t *testing.T) {
 }
 
 func TestPollEventToDigitalInputEventIgnoresUnknownDevices(t *testing.T) {
-	index := registry.Build(&config.File{})
+	index := registry.Build(&config.Root{})
 
 	_, ok := PollEventToDigitalInputEvent(index, sysfs.PollEvent{
 		Device: sysfs.Device{Identifier: "ro_3_14"},
@@ -41,7 +41,7 @@ func TestPollEventToDigitalInputEventIgnoresUnknownDevices(t *testing.T) {
 }
 
 func TestDigitalInputEventToPushButtonEvents(t *testing.T) {
-	index := registry.Build(&config.File{
+	index := registry.Build(&config.Root{
 		PushButtons: []config.PushButtonConfig{
 			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
 			{ID: "office_button_secondary", Name: "Office button secondary", Input: "office_button_input"},
@@ -61,7 +61,7 @@ func TestDigitalInputEventToPushButtonEvents(t *testing.T) {
 }
 
 func TestDigitalInputEventToPushButtonEventsIgnoresFallingEdge(t *testing.T) {
-	index := registry.Build(&config.File{
+	index := registry.Build(&config.Root{
 		PushButtons: []config.PushButtonConfig{{ID: "office_button", Name: "Office button", Input: "office_button_input"}},
 	})
 

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPollEventToDigitalInputEvent(t *testing.T) {
 	index := registry.Build(&entity.Root{
-		DigitalInputs: []entity.DigitalInput{{ID: "office_button_input", Device: "di_3_16"}},
+		DigitalInputs: []entity.DigitalInput{{ID: entity.DigitalInputID("office_button_input"), Device: entity.DeviceID("di_3_16")}},
 	})
 
 	event, ok := PollEventToDigitalInputEvent(index, sysfs.PollEvent{
@@ -25,8 +25,8 @@ func TestPollEventToDigitalInputEvent(t *testing.T) {
 	require.NotNil(t, event.DigitalInput)
 
 	assert.Equal(t, DigitalInputKind, event.Kind)
-	assert.Equal(t, "office_button_input", event.DigitalInput.InputID)
-	assert.Equal(t, "di_3_16", event.DigitalInput.DeviceID)
+	assert.Equal(t, entity.DigitalInputID("office_button_input"), event.DigitalInput.InputID)
+	assert.Equal(t, entity.DeviceID("di_3_16"), event.DigitalInput.DeviceID)
 	assert.True(t, event.DigitalInput.IsRising)
 	assert.False(t, event.DigitalInput.IsFalling)
 }
@@ -43,30 +43,30 @@ func TestPollEventToDigitalInputEventIgnoresUnknownDevices(t *testing.T) {
 func TestDigitalInputEventToPushButtonEvents(t *testing.T) {
 	index := registry.Build(&entity.Root{
 		PushButtons: []entity.PushButton{
-			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
-			{ID: "office_button_secondary", Name: "Office button secondary", Input: "office_button_input"},
+			{ID: entity.PushButtonID("office_button"), Name: "Office button", Input: entity.DigitalInputID("office_button_input")},
+			{ID: entity.PushButtonID("office_button_secondary"), Name: "Office button secondary", Input: entity.DigitalInputID("office_button_input")},
 		},
 	})
 
 	events := DigitalInputEventToPushButtonEvents(index, DigitalInputEvent{
-		InputID:  "office_button_input",
+		InputID:  entity.DigitalInputID("office_button_input"),
 		IsRising: true,
 	})
 	require.Len(t, events, 2)
 
 	assert.Equal(t, PushButtonKind, events[0].Kind)
-	assert.Equal(t, "office_button", events[0].PushButton.ButtonID)
+	assert.Equal(t, entity.PushButtonID("office_button"), events[0].PushButton.ButtonID)
 	assert.Equal(t, PushButtonPressed, events[0].PushButton.Kind)
-	assert.Equal(t, "office_button_secondary", events[1].PushButton.ButtonID)
+	assert.Equal(t, entity.PushButtonID("office_button_secondary"), events[1].PushButton.ButtonID)
 }
 
 func TestDigitalInputEventToPushButtonEventsIgnoresFallingEdge(t *testing.T) {
 	index := registry.Build(&entity.Root{
-		PushButtons: []entity.PushButton{{ID: "office_button", Name: "Office button", Input: "office_button_input"}},
+		PushButtons: []entity.PushButton{{ID: entity.PushButtonID("office_button"), Name: "Office button", Input: entity.DigitalInputID("office_button_input")}},
 	})
 
 	events := DigitalInputEventToPushButtonEvents(index, DigitalInputEvent{
-		InputID:   "office_button_input",
+		InputID:   entity.DigitalInputID("office_button_input"),
 		IsFalling: true,
 		IsRising:  false,
 	})

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -1,0 +1,74 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/registry"
+	"github.com/mhemeryck/nest/internal/sysfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPollEventToDigitalInputEvent(t *testing.T) {
+	index := registry.Build(&config.File{
+		DigitalInputs: []config.DigitalInputConfig{{ID: "office_button_input", Device: "di_3_16"}},
+	})
+
+	event, ok := PollEventToDigitalInputEvent(index, sysfs.PollEvent{
+		Device:   sysfs.Device{Identifier: "di_3_16"},
+		OldValue: sysfs.Off,
+		NewValue: sysfs.On,
+		IsRising: true,
+	})
+	require.True(t, ok)
+	require.NotNil(t, event.DigitalInput)
+
+	assert.Equal(t, DigitalInputKind, event.Kind)
+	assert.Equal(t, "office_button_input", event.DigitalInput.InputID)
+	assert.Equal(t, "di_3_16", event.DigitalInput.DeviceID)
+	assert.True(t, event.DigitalInput.IsRising)
+	assert.False(t, event.DigitalInput.IsFalling)
+}
+
+func TestPollEventToDigitalInputEventIgnoresUnknownDevices(t *testing.T) {
+	index := registry.Build(&config.File{})
+
+	_, ok := PollEventToDigitalInputEvent(index, sysfs.PollEvent{
+		Device: sysfs.Device{Identifier: "ro_3_14"},
+	})
+	assert.False(t, ok)
+}
+
+func TestDigitalInputEventToPushButtonEvents(t *testing.T) {
+	index := registry.Build(&config.File{
+		PushButtons: []config.PushButtonConfig{
+			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
+			{ID: "office_button_secondary", Name: "Office button secondary", Input: "office_button_input"},
+		},
+	})
+
+	events := DigitalInputEventToPushButtonEvents(index, DigitalInputEvent{
+		InputID:  "office_button_input",
+		IsRising: true,
+	})
+	require.Len(t, events, 2)
+
+	assert.Equal(t, PushButtonKind, events[0].Kind)
+	assert.Equal(t, "office_button", events[0].PushButton.ButtonID)
+	assert.Equal(t, PushButtonPressed, events[0].PushButton.Kind)
+	assert.Equal(t, "office_button_secondary", events[1].PushButton.ButtonID)
+}
+
+func TestDigitalInputEventToPushButtonEventsIgnoresFallingEdge(t *testing.T) {
+	index := registry.Build(&config.File{
+		PushButtons: []config.PushButtonConfig{{ID: "office_button", Name: "Office button", Input: "office_button_input"}},
+	})
+
+	events := DigitalInputEventToPushButtonEvents(index, DigitalInputEvent{
+		InputID:   "office_button_input",
+		IsFalling: true,
+		IsRising:  false,
+	})
+	assert.Empty(t, events)
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,16 +7,16 @@ import (
 )
 
 type Index struct {
-	DigitalInputsByDevice map[string]entity.DigitalInput
-	PushButtonsByInputID  map[string][]entity.PushButton
-	RelaysByDevice        map[string]entity.Relay
+	DigitalInputsByDevice map[entity.DeviceID]entity.DigitalInput
+	PushButtonsByInputID  map[entity.DigitalInputID][]entity.PushButton
+	RelaysByDevice        map[entity.DeviceID]entity.Relay
 }
 
 func Build(root *entity.Root) *Index {
 	index := &Index{
-		DigitalInputsByDevice: make(map[string]entity.DigitalInput, len(root.DigitalInputs)),
-		PushButtonsByInputID:  make(map[string][]entity.PushButton),
-		RelaysByDevice:        make(map[string]entity.Relay, len(root.Relays)),
+		DigitalInputsByDevice: make(map[entity.DeviceID]entity.DigitalInput, len(root.DigitalInputs)),
+		PushButtonsByInputID:  make(map[entity.DigitalInputID][]entity.PushButton),
+		RelaysByDevice:        make(map[entity.DeviceID]entity.Relay, len(root.Relays)),
 	}
 
 	for _, input := range root.DigitalInputs {
@@ -37,10 +37,10 @@ func Build(root *entity.Root) *Index {
 func DeviceIDs(index *Index) []string {
 	deviceIDs := make([]string, 0, len(index.DigitalInputsByDevice)+len(index.RelaysByDevice))
 	for deviceID := range index.DigitalInputsByDevice {
-		deviceIDs = append(deviceIDs, deviceID)
+		deviceIDs = append(deviceIDs, string(deviceID))
 	}
 	for deviceID := range index.RelaysByDevice {
-		deviceIDs = append(deviceIDs, deviceID)
+		deviceIDs = append(deviceIDs, string(deviceID))
 	}
 
 	sort.Strings(deviceIDs)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,48 @@
+package registry
+
+import (
+	"sort"
+
+	"github.com/mhemeryck/nest/internal/config"
+)
+
+type Index struct {
+	DigitalInputsByDevice map[string]config.DigitalInputConfig
+	PushButtonsByInputID  map[string][]config.PushButtonConfig
+	RelaysByDevice        map[string]config.RelayConfig
+}
+
+func Build(file *config.File) *Index {
+	index := &Index{
+		DigitalInputsByDevice: make(map[string]config.DigitalInputConfig, len(file.DigitalInputs)),
+		PushButtonsByInputID:  make(map[string][]config.PushButtonConfig),
+		RelaysByDevice:        make(map[string]config.RelayConfig, len(file.Relays)),
+	}
+
+	for _, input := range file.DigitalInputs {
+		index.DigitalInputsByDevice[input.Device] = input
+	}
+
+	for _, button := range file.PushButtons {
+		index.PushButtonsByInputID[button.Input] = append(index.PushButtonsByInputID[button.Input], button)
+	}
+
+	for _, relay := range file.Relays {
+		index.RelaysByDevice[relay.Device] = relay
+	}
+
+	return index
+}
+
+func DeviceIDs(index *Index) []string {
+	deviceIDs := make([]string, 0, len(index.DigitalInputsByDevice)+len(index.RelaysByDevice))
+	for deviceID := range index.DigitalInputsByDevice {
+		deviceIDs = append(deviceIDs, deviceID)
+	}
+	for deviceID := range index.RelaysByDevice {
+		deviceIDs = append(deviceIDs, deviceID)
+	}
+
+	sort.Strings(deviceIDs)
+	return deviceIDs
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,7 +1,7 @@
 package registry
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/mhemeryck/nest/internal/entity"
 )
@@ -34,15 +34,16 @@ func Build(root *entity.Root) *Index {
 	return index
 }
 
-func DeviceIDs(index *Index) []string {
-	deviceIDs := make([]string, 0, len(index.DigitalInputsByDevice)+len(index.RelaysByDevice))
+func DeviceIDs(index *Index) []entity.DeviceID {
+	deviceIDs := make([]entity.DeviceID, 0, len(index.DigitalInputsByDevice)+len(index.RelaysByDevice))
 	for deviceID := range index.DigitalInputsByDevice {
-		deviceIDs = append(deviceIDs, string(deviceID))
+		deviceIDs = append(deviceIDs, deviceID)
 	}
 	for deviceID := range index.RelaysByDevice {
-		deviceIDs = append(deviceIDs, string(deviceID))
+		deviceIDs = append(deviceIDs, deviceID)
 	}
 
-	sort.Strings(deviceIDs)
+	slices.Sort(deviceIDs)
+
 	return deviceIDs
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -12,7 +12,7 @@ type Index struct {
 	RelaysByDevice        map[string]config.RelayConfig
 }
 
-func Build(file *config.File) *Index {
+func Build(file *config.Root) *Index {
 	index := &Index{
 		DigitalInputsByDevice: make(map[string]config.DigitalInputConfig, len(file.DigitalInputs)),
 		PushButtonsByInputID:  make(map[string][]config.PushButtonConfig),

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -3,31 +3,31 @@ package registry
 import (
 	"sort"
 
-	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/entity"
 )
 
 type Index struct {
-	DigitalInputsByDevice map[string]config.DigitalInputConfig
-	PushButtonsByInputID  map[string][]config.PushButtonConfig
-	RelaysByDevice        map[string]config.RelayConfig
+	DigitalInputsByDevice map[string]entity.DigitalInput
+	PushButtonsByInputID  map[string][]entity.PushButton
+	RelaysByDevice        map[string]entity.Relay
 }
 
-func Build(file *config.Root) *Index {
+func Build(root *entity.Root) *Index {
 	index := &Index{
-		DigitalInputsByDevice: make(map[string]config.DigitalInputConfig, len(file.DigitalInputs)),
-		PushButtonsByInputID:  make(map[string][]config.PushButtonConfig),
-		RelaysByDevice:        make(map[string]config.RelayConfig, len(file.Relays)),
+		DigitalInputsByDevice: make(map[string]entity.DigitalInput, len(root.DigitalInputs)),
+		PushButtonsByInputID:  make(map[string][]entity.PushButton),
+		RelaysByDevice:        make(map[string]entity.Relay, len(root.Relays)),
 	}
 
-	for _, input := range file.DigitalInputs {
+	for _, input := range root.DigitalInputs {
 		index.DigitalInputsByDevice[input.Device] = input
 	}
 
-	for _, button := range file.PushButtons {
+	for _, button := range root.PushButtons {
 		index.PushButtonsByInputID[button.Input] = append(index.PushButtonsByInputID[button.Input], button)
 	}
 
-	for _, relay := range file.Relays {
+	for _, relay := range root.Relays {
 		index.RelaysByDevice[relay.Device] = relay
 	}
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -3,29 +3,29 @@ package registry
 import (
 	"testing"
 
-	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuild(t *testing.T) {
-	file := &config.Root{
-		DigitalInputs: []config.DigitalInputConfig{
+	root := &entity.Root{
+		DigitalInputs: []entity.DigitalInput{
 			{ID: "office_button_input", Device: "di_3_16"},
 		},
-		PushButtons: []config.PushButtonConfig{
+		PushButtons: []entity.PushButton{
 			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
 		},
-		Relays: []config.RelayConfig{
+		Relays: []entity.Relay{
 			{ID: "office_shade_up", Name: "Office shade up", Device: "ro_3_14"},
 		},
 	}
 
-	index := Build(file)
+	index := Build(root)
 	require.NotNil(t, index)
 
-	assert.Equal(t, file.DigitalInputs[0], index.DigitalInputsByDevice["di_3_16"])
-	assert.Equal(t, file.PushButtons, index.PushButtonsByInputID["office_button_input"])
-	assert.Equal(t, file.Relays[0], index.RelaysByDevice["ro_3_14"])
+	assert.Equal(t, root.DigitalInputs[0], index.DigitalInputsByDevice["di_3_16"])
+	assert.Equal(t, root.PushButtons, index.PushButtonsByInputID["office_button_input"])
+	assert.Equal(t, root.Relays[0], index.RelaysByDevice["ro_3_14"])
 	assert.Equal(t, []string{"di_3_16", "ro_3_14"}, DeviceIDs(index))
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,31 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuild(t *testing.T) {
+	file := &config.File{
+		DigitalInputs: []config.DigitalInputConfig{
+			{ID: "office_button_input", Device: "di_3_16"},
+		},
+		PushButtons: []config.PushButtonConfig{
+			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
+		},
+		Relays: []config.RelayConfig{
+			{ID: "office_shade_up", Name: "Office shade up", Device: "ro_3_14"},
+		},
+	}
+
+	index := Build(file)
+	require.NotNil(t, index)
+
+	assert.Equal(t, file.DigitalInputs[0], index.DigitalInputsByDevice["di_3_16"])
+	assert.Equal(t, file.PushButtons, index.PushButtonsByInputID["office_button_input"])
+	assert.Equal(t, file.Relays[0], index.RelaysByDevice["ro_3_14"])
+	assert.Equal(t, []string{"di_3_16", "ro_3_14"}, DeviceIDs(index))
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBuild(t *testing.T) {
-	file := &config.File{
+	file := &config.Root{
 		DigitalInputs: []config.DigitalInputConfig{
 			{ID: "office_button_input", Device: "di_3_16"},
 		},

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -27,5 +27,5 @@ func TestBuild(t *testing.T) {
 	assert.Equal(t, root.DigitalInputs[0], index.DigitalInputsByDevice[entity.DeviceID("di_3_16")])
 	assert.Equal(t, root.PushButtons, index.PushButtonsByInputID[entity.DigitalInputID("office_button_input")])
 	assert.Equal(t, root.Relays[0], index.RelaysByDevice[entity.DeviceID("ro_3_14")])
-	assert.Equal(t, []string{"di_3_16", "ro_3_14"}, DeviceIDs(index))
+	assert.Equal(t, []entity.DeviceID{"di_3_16", "ro_3_14"}, DeviceIDs(index))
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -11,21 +11,21 @@ import (
 func TestBuild(t *testing.T) {
 	root := &entity.Root{
 		DigitalInputs: []entity.DigitalInput{
-			{ID: "office_button_input", Device: "di_3_16"},
+			{ID: entity.DigitalInputID("office_button_input"), Device: entity.DeviceID("di_3_16")},
 		},
 		PushButtons: []entity.PushButton{
-			{ID: "office_button", Name: "Office button", Input: "office_button_input"},
+			{ID: entity.PushButtonID("office_button"), Name: "Office button", Input: entity.DigitalInputID("office_button_input")},
 		},
 		Relays: []entity.Relay{
-			{ID: "office_shade_up", Name: "Office shade up", Device: "ro_3_14"},
+			{ID: entity.RelayID("office_shade_up"), Name: "Office shade up", Device: entity.DeviceID("ro_3_14")},
 		},
 	}
 
 	index := Build(root)
 	require.NotNil(t, index)
 
-	assert.Equal(t, root.DigitalInputs[0], index.DigitalInputsByDevice["di_3_16"])
-	assert.Equal(t, root.PushButtons, index.PushButtonsByInputID["office_button_input"])
-	assert.Equal(t, root.Relays[0], index.RelaysByDevice["ro_3_14"])
+	assert.Equal(t, root.DigitalInputs[0], index.DigitalInputsByDevice[entity.DeviceID("di_3_16")])
+	assert.Equal(t, root.PushButtons, index.PushButtonsByInputID[entity.DigitalInputID("office_button_input")])
+	assert.Equal(t, root.Relays[0], index.RelaysByDevice[entity.DeviceID("ro_3_14")])
 	assert.Equal(t, []string{"di_3_16", "ro_3_14"}, DeviceIDs(index))
 }

--- a/internal/sysfs/device.go
+++ b/internal/sysfs/device.go
@@ -108,6 +108,17 @@ func writeValue(path string, value Value) error {
 	return os.WriteFile(path, []byte{byte(value), '\n'}, 0o644)
 }
 
+func PrintableValue(value Value) int {
+	switch value {
+	case Off:
+		return 0
+	case On:
+		return 1
+	default:
+		return int(value)
+	}
+}
+
 func readDevice(device *Device) (Value, error) {
 	value, err := readValue(device.Path)
 	if err != nil {

--- a/internal/sysfs/sysfs_test.go
+++ b/internal/sysfs/sysfs_test.go
@@ -45,6 +45,12 @@ func TestWriteValueRejectsInvalidValue(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPrintableValue(t *testing.T) {
+	assert.Equal(t, 0, PrintableValue(Off))
+	assert.Equal(t, 1, PrintableValue(On))
+	assert.Equal(t, int(Value('x')), PrintableValue(Value('x')))
+}
+
 func TestListDevices(t *testing.T) {
 	fixtures := filepath.Join("..", "..", "test", "fixtures")
 

--- a/test/fixtures/config.local.yaml
+++ b/test/fixtures/config.local.yaml
@@ -1,0 +1,19 @@
+sysfs:
+  root: test/fixtures
+
+digital_inputs:
+  - id: office_button_input
+    device: di_3_16
+
+push_buttons:
+  - id: office_button
+    name: Office shade button
+    input: office_button_input
+
+relays:
+  - id: office_shade_up
+    name: Office shade up
+    device: ro_3_14
+  - id: office_shade_down
+    name: Office shade down
+    device: ro_3_13


### PR DESCRIPTION
Add the initial local controller foundation.

Introduce strict YAML config loading and validation for local
sysfs-backed digital inputs, push buttons, and relays.
Build explicit entity and registry layers with typed IDs, and
add the first local event pipeline from sysfs poll events to
digital input and push button events.

Extract the orchestration loop into `internal/controller` and
tighten startup checks so invalid config, duplicate device
mappings, padded values, trailing YAML documents, and sysfs
startup failures are rejected early.
