### PR TITLE
Refactor runtime application boundary

### DIFF
--- a/cmd/nest/main.go
+++ b/cmd/nest/main.go
@@ -6,14 +6,9 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"slices"
 	"syscall"
 
-	"github.com/mhemeryck/nest/internal/config"
-	"github.com/mhemeryck/nest/internal/controller"
-	"github.com/mhemeryck/nest/internal/entity"
-	"github.com/mhemeryck/nest/internal/registry"
-	"github.com/mhemeryck/nest/internal/sysfs"
+	"github.com/mhemeryck/nest/internal/nest"
 )
 
 func main() {
@@ -21,78 +16,11 @@ func main() {
 	validateOnly := flag.Bool("validate", false, "Validate config and exit")
 	flag.Parse()
 
-	configRoot, err := config.Load(*configPath)
-	if err != nil {
-		slog.Error("load config failed", "error", err)
-		os.Exit(1)
-	}
-
-	if *validateOnly {
-		slog.Info("config is valid", "path", *configPath)
-		return
-	}
-
-	root := entity.FromConfig(configRoot)
-	index := registry.Build(root)
-
-	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
-	devices, err := sysfs.ListDevices(root.SysfsRoot)
-	if err != nil {
-		slog.Error("crawl failed", "error", err)
-		os.Exit(1)
-	}
-
-	configuredDevices, missing := configuredDevices(devices, registry.DeviceIDs(index))
-	if len(missing) > 0 {
-		for _, deviceID := range missing {
-			slog.Error("configured device not found in sysfs", "device_id", deviceID)
-		}
-		os.Exit(1)
-	}
-
-	slog.Info("configured devices", "count", len(configuredDevices))
-	for _, device := range configuredDevices {
-		slog.Info("configured device", "identifier", device.Identifier, "path", device.Path)
-	}
-
-	commands := make(chan sysfs.Command, 32)
-	states := make(chan sysfs.StateChange, 32)
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	sysfsDone := make(chan struct{})
-	go sysfs.Run(ctx, configuredDevices, commands, states, sysfsDone)
 
-	controllerDone := make(chan struct{})
-	go controller.Run(ctx, index, commands, states, controllerDone)
-
-	slog.Info("polling devices", "message", "press Ctrl+C to exit")
-
-	<-controllerDone
-	stop()
-	<-sysfsDone
-	close(states)
-
-	slog.Info("shutting down")
-}
-
-func configuredDevices(devices []*sysfs.Device, wanted []entity.DeviceID) ([]*sysfs.Device, []entity.DeviceID) {
-	byIdentifier := make(map[string]*sysfs.Device, len(devices))
-	for _, device := range devices {
-		byIdentifier[device.Identifier] = device
+	if err := nest.Run(ctx, nest.Options{ConfigPath: *configPath, ValidateOnly: *validateOnly}); err != nil {
+		slog.Error("run failed", "error", err)
+		os.Exit(1)
 	}
-
-	configured := make([]*sysfs.Device, 0, len(wanted))
-	missing := make([]entity.DeviceID, 0)
-	for _, identifier := range wanted {
-		device, ok := byIdentifier[string(identifier)]
-		if !ok {
-			missing = append(missing, identifier)
-			continue
-		}
-		configured = append(configured, device)
-	}
-
-	slices.Sort(missing)
-
-	return configured, missing
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -48,6 +48,23 @@ This keeps ownership explicit.
 It also fits sysfs, MQTT, and Modbus well.
 Each integration can own its protocol or device state locally while the controller remains the only router between domains.
 
+Actor packages should stay focused on their own protocol or device behavior.
+They should expose actor-specific observations and commands, such as `sysfs.StateChange`, `sysfs.Command`, or future actor equivalents.
+They should not translate directly to other actors.
+
+The controller owns runtime translation between actor-specific observations and controller-level events.
+Current event normalization should live under `internal/controller/event` to make that ownership explicit while keeping translation code separate from the main control loop.
+As new actors are added, each actor should add one controller-side normalization path into controller events rather than direct actor-to-actor translations.
+
+The registry is the runtime lookup layer built from domain entities.
+It maps configured entity relationships and actor-facing identifiers back to typed entities, such as sysfs device IDs to inputs or relays.
+Future transport address lookup indexes can live in the registry when command handling needs them.
+The registry should not carry actor runtime configuration, credentials, live clients, channels, or reconnect state.
+
+The top-level `internal/nest` package owns application wiring.
+It loads config, builds domain entities, builds registries, discovers configured devices, maps domain config into actor-specific runtime config, starts actors, and coordinates shutdown.
+The `cmd/nest` package should remain a thin process entrypoint for CLI parsing, signal handling, and exit status.
+
 ### Runtime Flow
 
 The controller is the central coordinator.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -37,13 +37,18 @@ Covers come later because motor control adds safety requirements around up/down 
 
 ## Phase 3: Build and Deploy Pipeline
 
-- [ ] Add GoReleaser configuration
-- [ ] Build Linux ARM artifacts for the Raspberry Pi controller
-- [ ] Keep CI checks for vet, tests, and normal builds
-- [ ] Publish CI artifacts for controller deployment
-- [ ] Optionally publish release artifacts from tags
+- [x] Add GoReleaser configuration
+- [x] Build Linux ARM artifacts for the Raspberry Pi controller
+- [x] Keep CI checks for vet, tests, and normal builds
+- [x] Run validation on pull requests through a reusable workflow
+- [x] Support manual snapshot artifact builds for a selected ref
+- [x] Upload manual snapshot artifacts for controller deployment
+- [x] Create automatic GitHub releases on merges to `master`
+- [x] Use UTC CalVer release tags with date, hour, minute, and second
+- [x] Attach controller artifacts and checksums to GitHub releases
+- [x] Include generated changelogs in GitHub releases
 
-**Deliverable**: `nest` can produce a controller-ready binary artifact consistently.
+**Deliverable**: `nest` can produce controller-ready artifacts on demand and publish release artifacts automatically from `master`.
 
 ## Phase 4: Passive MQTT Observability and Discovery
 

--- a/docs/refactor-notes.md
+++ b/docs/refactor-notes.md
@@ -1,0 +1,115 @@
+# Runtime Boundary Refactor Notes
+
+## Context
+
+The next runtime phases exposed several package boundary issues.
+The package structure should be cleaned up before adding more integrations or observability behavior.
+
+The refactor is not tied to a single actor or transport.
+It affects the baseline runtime architecture around controller coordination, event normalization, registry lookups, actor boundaries, and top-level wiring.
+
+## Recommended Sequence
+
+Move the non-integration-specific runtime refactors first.
+After that refactor is merged, add new actor behavior on top of the cleaned architecture.
+This should keep future feature branches focused on behavior rather than mixing them with foundational package movement.
+
+## Target Responsibilities
+
+### `cmd/nest`
+
+`cmd/nest` should stay a thin process entrypoint.
+It should own CLI parsing, signal setup, calling the application runtime, logging fatal errors, and process exit status.
+
+It should not own application wiring, actor startup, config-to-runtime mapping, or shutdown ordering.
+
+### `internal/nest`
+
+`internal/nest` should own top-level application wiring.
+It should load parsed config, build domain entities, build runtime lookup indexes, discover configured devices, create channels, start actors, start the controller, and coordinate shutdown.
+
+It is also the right place for config-to-package-specific runtime mapping.
+Parsed or domain config should be translated into actor runtime config before starting actors.
+
+### Actor Packages
+
+Actor packages should stay focused on their own protocol or device behavior.
+Examples are sysfs and future transport or integration actors.
+
+Actors should expose actor-specific observations and commands.
+Examples are `sysfs.StateChange`, `sysfs.Command`, and future actor equivalents.
+
+Actors should not translate directly to other actors.
+They should not know about controller policy or unrelated actor protocols.
+
+### `internal/controller`
+
+The controller is the central runtime bus and policy layer.
+It consumes actor observations, normalizes them into controller-level events, applies bindings and runtime rules, and emits actor commands or actor state publications.
+
+The controller is allowed to import actor packages, registry lookups, and controller-owned event translation code.
+This is the intended integration point.
+
+Avoid global controller state.
+If function signatures become noisy, prefer explicit state or dependency structs passed to package-level functions.
+Do not introduce receiver methods for project types by default.
+
+### Controller Events
+
+Events are controller-owned normalized messages.
+They are not actors and are not a global app-wide abstraction unless later proven necessary.
+
+A reasonable package shape is `internal/controller/event`.
+That package can define controller event types and hold actor-to-event normalization helpers.
+
+This keeps translation code separate from the main controller loop while making ownership clear.
+For example, sysfs observations can normalize to digital input or push button events before controller policy is applied.
+
+### Registry
+
+The registry is a table of mappings used by the controller and event normalization code.
+It should answer what a runtime address, topic, coil, or entity relationship refers to.
+
+The registry is complementary to events.
+The registry resolves identities and relationships.
+Events describe what happened after normalization.
+The controller uses both to decide what should happen next.
+
+The registry may contain actor-facing mappings such as sysfs device IDs to entities or future transport addresses to entities.
+It should not contain live actor runtime state such as clients, goroutines, channels, reconnect state, credentials, or mutable protocol state.
+
+It may be worth moving registry under the controller namespace later, for example `internal/controller/registry`.
+That should only happen after separating controller lookup needs from general setup or discovery needs.
+
+## Possible Future Shape
+
+One possible long-term package layout is:
+
+```text
+internal/
+  nest/
+  controller/
+    event/
+    registry/
+  actors/
+    sysfs/
+    modbus/
+  config/
+  entity/
+```
+
+This should not be done just to mirror the architecture diagram.
+Move actors under an `actors` folder when another actor makes the grouping useful.
+
+## Immediate Refactor Candidates
+
+Extract `cmd/nest` runtime wiring into `internal/nest`.
+Move current `internal/event` under `internal/controller/event` or otherwise make it clearly controller-owned.
+Group registry mappings by purpose, such as domain mappings, sysfs mappings, and later transport mappings.
+Keep actor packages focused on actor behavior and keep cross-actor translation in controller-owned code.
+
+## Open Questions
+
+Should registry remain app-wide, or should it become `internal/controller/registry`?
+When command topics or transport addresses are added, should they be parsed by the actor or resolved through registry mappings?
+When additional actors are added, should actor grouping move all actors under `internal/actors` in the same refactor?

--- a/internal/nest/devices.go
+++ b/internal/nest/devices.go
@@ -1,0 +1,30 @@
+package nest
+
+import (
+	"slices"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/sysfs"
+)
+
+func configuredDevices(devices []*sysfs.Device, wanted []entity.DeviceID) ([]*sysfs.Device, []entity.DeviceID) {
+	byIdentifier := make(map[string]*sysfs.Device, len(devices))
+	for _, device := range devices {
+		byIdentifier[device.Identifier] = device
+	}
+
+	configured := make([]*sysfs.Device, 0, len(wanted))
+	missing := make([]entity.DeviceID, 0)
+	for _, identifier := range wanted {
+		device, ok := byIdentifier[string(identifier)]
+		if !ok {
+			missing = append(missing, identifier)
+			continue
+		}
+		configured = append(configured, device)
+	}
+
+	slices.Sort(missing)
+
+	return configured, missing
+}

--- a/internal/nest/devices_test.go
+++ b/internal/nest/devices_test.go
@@ -1,0 +1,28 @@
+package nest
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/sysfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfiguredDevices(t *testing.T) {
+	devices := []*sysfs.Device{
+		{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
+		{Identifier: "ro_3_14", Path: "/sys/ro_3_14/ro_value"},
+		{Identifier: "di_3_15", Path: "/sys/di_3_15/di_value"},
+	}
+	wanted := []entity.DeviceID{
+		entity.DeviceID("ro_3_14"),
+		entity.DeviceID("missing_2"),
+		entity.DeviceID("di_3_16"),
+		entity.DeviceID("missing_1"),
+	}
+
+	configured, missing := configuredDevices(devices, wanted)
+
+	assert.Equal(t, []*sysfs.Device{devices[1], devices[0]}, configured)
+	assert.Equal(t, []entity.DeviceID{entity.DeviceID("missing_1"), entity.DeviceID("missing_2")}, missing)
+}

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -1,0 +1,76 @@
+package nest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/controller"
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/registry"
+	"github.com/mhemeryck/nest/internal/sysfs"
+)
+
+type Options struct {
+	ConfigPath   string
+	ValidateOnly bool
+}
+
+func Run(ctx context.Context, opts Options) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	configRoot, err := config.Load(opts.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	if opts.ValidateOnly {
+		slog.Info("config is valid", "path", opts.ConfigPath)
+		return nil
+	}
+
+	root := entity.FromConfig(configRoot)
+	index := registry.Build(root)
+
+	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
+	devices, err := sysfs.ListDevices(root.SysfsRoot)
+	if err != nil {
+		return fmt.Errorf("crawl sysfs: %w", err)
+	}
+
+	configuredDevices, missing := configuredDevices(devices, registry.DeviceIDs(index))
+	if len(missing) > 0 {
+		var errs error
+		for _, deviceID := range missing {
+			slog.Error("configured device not found in sysfs", "device_id", deviceID)
+			errs = errors.Join(errs, fmt.Errorf("configured device %q not found in sysfs", deviceID))
+		}
+		return errs
+	}
+
+	slog.Info("configured devices", "count", len(configuredDevices))
+	for _, device := range configuredDevices {
+		slog.Info("configured device", "identifier", device.Identifier, "path", device.Path)
+	}
+
+	commands := make(chan sysfs.Command, 32)
+	states := make(chan sysfs.StateChange, 32)
+	sysfsDone := make(chan struct{})
+	go sysfs.Run(ctx, configuredDevices, commands, states, sysfsDone)
+
+	controllerDone := make(chan struct{})
+	go controller.Run(ctx, index, commands, states, controllerDone)
+
+	slog.Info("polling devices", "message", "press Ctrl+C to exit")
+
+	<-controllerDone
+	cancel()
+	<-sysfsDone
+	close(states)
+
+	slog.Info("shutting down")
+	return nil
+}

--- a/internal/nest/nest_test.go
+++ b/internal/nest/nest_test.go
@@ -1,0 +1,24 @@
+package nest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunValidateOnlyAcceptsValidConfig(t *testing.T) {
+	err := Run(t.Context(), Options{
+		ConfigPath:   filepath.Join("..", "..", "test", "fixtures", "config.local.yaml"),
+		ValidateOnly: true,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestRunValidateOnlyReturnsLoadError(t *testing.T) {
+	err := Run(t.Context(), Options{ConfigPath: filepath.Join(t.TempDir(), "missing.yaml"), ValidateOnly: true})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "load config")
+}


### PR DESCRIPTION
Document the intended runtime package boundaries and move the
application wiring from cmd/nest into internal/nest.

This keeps the command package focused on CLI parsing, signal handling,
and process exit behavior while giving future actors a dedicated top-level
runtime wiring package.