### PR TITLE
Add passive MQTT observability

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -76,16 +76,20 @@ Covers come later because motor control adds safety requirements around up/down 
 
 ## Phase 5: Passive MQTT Observability and Discovery
 
-- [ ] Add MQTT broker configuration
-- [ ] Treat MQTT as an actor with a command channel into MQTT and an event channel back to `nest`
-- [ ] Publish only semantic observations emitted by `nest` runtime or controller code
-- [ ] Publish unit availability
-- [ ] Publish mapped input observations and state
-- [ ] Publish mapped relay state changes
-- [ ] Publish a retained unit autodiscovery document on a dedicated discovery topic
-- [ ] Include state topics, command topics, entity IDs, capabilities, and command enablement in discovery
-- [ ] Do not subscribe to command topics yet
-- [ ] Do not let MQTT behavior write relay outputs yet
+- [x] Add MQTT broker configuration
+- [x] Treat MQTT as an actor with a command channel into MQTT and an event channel back to `nest`
+- [x] Publish only semantic observations emitted by `nest` runtime or controller code
+- [x] Publish unit availability
+- [x] Publish mapped input observations and state
+- [x] Publish mapped push button observations and state
+- [x] Publish mapped relay state changes
+- [ ] Publish mapped light state changes
+- [x] Publish a retained unit autodiscovery document on a dedicated discovery topic
+- [x] Include state topics, command topics, entity IDs, capabilities, and command enablement in discovery
+- [x] Do not subscribe to command topics yet
+- [x] Do not let MQTT behavior write relay outputs yet
+- [x] Add local MQTT fixture for manual broker verification
+- [x] Document local Mosquitto and `mosquitto_sub` verification flow
 
 **Deliverable**: `nest` can run beside the current setup and expose what it observes without taking control.
 
@@ -98,6 +102,25 @@ Boundary note:
 - MQTT must not consume from sysfs actor channels directly
 - MQTT should publish semantic observations only, not raw sysfs diagnostics
 - MQTT must not subscribe to command topics or produce actor commands
+
+Current status:
+
+- MQTT config, actor wiring, startup availability, retained discovery, and semantic input, push button, and relay publishing are implemented
+- Manual local broker verification published availability, digital input, push button, and relay state messages under `nest/units/local/...`
+- Light state publishing still needs to be decided and implemented
+- Reconnect republishing and offline availability are deferred to MQTT contract hardening unless needed earlier
+
+Manual verification sample:
+
+```text
+nest/units/local/availability online
+nest/units/local/digital_inputs/office_button_input/state {"input_id":"office_button_input","sysfs_device":"di_3_16","value":1}
+nest/units/local/push_buttons/office_button/state {"button_id":"office_button","name":"Office light button","state":"pressed"}
+nest/units/local/relays/office_light_relay/state {"relay_id":"office_light_relay","name":"Office light relay","sysfs_device":"ro_3_14","value":1}
+nest/units/local/digital_inputs/office_button_input/state {"input_id":"office_button_input","sysfs_device":"di_3_16","value":0}
+nest/units/local/push_buttons/office_button/state {"button_id":"office_button","name":"Office light button","state":"released"}
+nest/units/local/relays/office_light_relay/state {"relay_id":"office_light_relay","name":"Office light relay","sysfs_device":"ro_3_14","value":0}
+```
 
 ## Phase 6: MQTT Contract Hardening
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -132,8 +132,17 @@ nest/units/local/relays/office_light_relay/state {"relay_id":"office_light_relay
 - [ ] Add schema versioning for discovery documents
 - [ ] Decide retained vs non-retained behavior per topic class
 - [ ] Handle reconnects and republish availability and discovery
+- [ ] Add MQTT Last Will and graceful offline availability publishing
 - [ ] Add logging for publish failures and dropped messages
+- [ ] Decide whether dropped publish warnings need rate limiting or counters
 - [ ] Add tests for generated topics and discovery payloads
+
+Notes from the earlier passive MQTT prototype:
+
+- MQTT Last Will and offline availability are useful, but should be part of contract hardening rather than the first passive publishing slice
+- Reconnect handling should republish retained discovery and availability so subscribers recover after broker interruptions
+- Dropped MQTT publish logging is useful for visibility, but may need rate limiting if frequent input changes happen while the broker is unavailable
+- Home Assistant discovery should remain separate from the unit-level `nest` discovery contract until the MQTT topic and payload schema are stable
 
 **Deliverable**: MQTT telemetry and discovery are reliable enough to guide migration decisions.
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -90,6 +90,7 @@ Covers come later because motor control adds safety requirements around up/down 
 - [x] Do not let MQTT behavior write relay outputs yet
 - [x] Add local MQTT fixture for manual broker verification
 - [x] Document local Mosquitto and `mosquitto_sub` verification flow
+- [ ] Consider replacing repeated controller dispatch parameters with a data-only dispatch context
 
 **Deliverable**: `nest` can run beside the current setup and expose what it observes without taking control.
 
@@ -108,6 +109,8 @@ Current status:
 - MQTT config, actor wiring, startup availability, retained discovery, and semantic input, push button, and relay publishing are implemented
 - Manual local broker verification published availability, digital input, push button, and relay state messages under `nest/units/local/...`
 - Light state publishing still needs to be decided and implemented
+- Controller dispatch currently passes registry, sysfs command channel, MQTT command channel, and MQTT topics through several helpers
+- A follow-up refactor could introduce an unexported data-only dispatch context passed to package-level functions, without receiver methods
 - Reconnect republishing and offline availability are deferred to MQTT contract hardening unless needed earlier
 
 Manual verification sample:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -90,7 +90,7 @@ Covers come later because motor control adds safety requirements around up/down 
 - [x] Do not let MQTT behavior write relay outputs yet
 - [x] Add local MQTT fixture for manual broker verification
 - [x] Document local Mosquitto and `mosquitto_sub` verification flow
-- [ ] Consider replacing repeated controller dispatch parameters with a data-only dispatch context
+- [x] ~~Consider replacing repeated controller dispatch parameters with a data-only dispatch context~~
 
 **Deliverable**: `nest` can run beside the current setup and expose what it observes without taking control.
 
@@ -109,8 +109,8 @@ Current status:
 - MQTT config, actor wiring, startup availability, retained discovery, and semantic input, push button, and relay publishing are implemented
 - Manual local broker verification published availability, digital input, push button, and relay state messages under `nest/units/local/...`
 - Light state publishing is derived from relay state for relay-backed local lights
-- Controller dispatch currently passes registry, sysfs command channel, MQTT command channel, and MQTT topics through several helpers
-- A follow-up refactor could introduce an unexported data-only dispatch context passed to package-level functions, without receiver methods
+- ~~Controller dispatch currently passes registry, sysfs command channel, MQTT command channel, and MQTT topics through several helpers~~
+- Superseded by splitting semantic event dispatch into actor-specific command dispatchers instead of adding a context bag
 - Reconnect republishing and offline availability are deferred to MQTT contract hardening unless needed earlier
 
 Manual verification sample:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -77,8 +77,8 @@ Covers come later because motor control adds safety requirements around up/down 
 ## Phase 5: Passive MQTT Observability and Discovery
 
 - [ ] Add MQTT broker configuration
+- [ ] Publish only semantic observations emitted by `nest` runtime or controller code
 - [ ] Publish unit availability
-- [ ] Publish observed raw sysfs state changes
 - [ ] Publish mapped input observations and state
 - [ ] Publish mapped relay state changes
 - [ ] Publish a retained unit autodiscovery document on a dedicated discovery topic
@@ -87,6 +87,13 @@ Covers come later because motor control adds safety requirements around up/down 
 - [ ] Do not let MQTT behavior write relay outputs yet
 
 **Deliverable**: `nest` can run beside the current setup and expose what it observes without taking control.
+
+Boundary note:
+
+- MQTT is a passive publisher for `nest` observations in this phase
+- MQTT must not consume from sysfs actor channels directly
+- MQTT should publish semantic observations only, not raw sysfs diagnostics
+- MQTT must not subscribe to command topics or produce actor commands
 
 ## Phase 6: MQTT Contract Hardening
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -77,6 +77,7 @@ Covers come later because motor control adds safety requirements around up/down 
 ## Phase 5: Passive MQTT Observability and Discovery
 
 - [ ] Add MQTT broker configuration
+- [ ] Treat MQTT as an actor with a command channel into MQTT and an event channel back to `nest`
 - [ ] Publish only semantic observations emitted by `nest` runtime or controller code
 - [ ] Publish unit availability
 - [ ] Publish mapped input observations and state
@@ -91,6 +92,9 @@ Covers come later because motor control adds safety requirements around up/down 
 Boundary note:
 
 - MQTT is a passive publisher for `nest` observations in this phase
+- MQTT communication with the rest of the runtime uses two unidirectional channels
+- `nest` sends publish commands to the MQTT actor
+- the MQTT actor sends connection and publish status events back to `nest`
 - MQTT must not consume from sysfs actor channels directly
 - MQTT should publish semantic observations only, not raw sysfs diagnostics
 - MQTT must not subscribe to command topics or produce actor commands

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -83,7 +83,7 @@ Covers come later because motor control adds safety requirements around up/down 
 - [x] Publish mapped input observations and state
 - [x] Publish mapped push button observations and state
 - [x] Publish mapped relay state changes
-- [ ] Publish mapped light state changes
+- [x] Publish mapped light state changes
 - [x] Publish a retained unit autodiscovery document on a dedicated discovery topic
 - [x] Include state topics, command topics, entity IDs, capabilities, and command enablement in discovery
 - [x] Do not subscribe to command topics yet
@@ -108,7 +108,7 @@ Current status:
 
 - MQTT config, actor wiring, startup availability, retained discovery, and semantic input, push button, and relay publishing are implemented
 - Manual local broker verification published availability, digital input, push button, and relay state messages under `nest/units/local/...`
-- Light state publishing still needs to be decided and implemented
+- Light state publishing is derived from relay state for relay-backed local lights
 - Controller dispatch currently passes registry, sysfs command channel, MQTT command channel, and MQTT topics through several helpers
 - A follow-up refactor could introduce an unexported data-only dispatch context passed to package-level functions, without receiver methods
 - Reconnect republishing and offline availability are deferred to MQTT contract hardening unless needed earlier

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -248,3 +248,31 @@ These should be decided before transport and entity complexity increase.
 - [ ] Whether Modbus output units execute semantic commands or expose coil-level relay control
 - [ ] Whether command topics or transport addresses should be parsed by the actor or resolved through registry mappings
 - [ ] Whether actor grouping should move integrations under `internal/actors` once a second actor makes the grouping useful
+
+## Future Config Distribution Direction
+
+Out of scope for the current MQTT observability phase, but useful for guiding registry and topic-index decisions.
+
+Eventually, configuration may come from a central/global source that describes all controller units and their relationships.
+
+That global configuration could be distributed to each unit, possibly over MQTT or another control plane.
+Each unit would project the global configuration into the subset it needs locally, then build its local runtime state from that projection.
+
+The intended layering should stay roughly:
+
+```text
+global config
+  -> unit-local config projection
+  -> parsed config structs
+  -> domain entities
+  -> runtime registries/indexes
+  -> actor-specific addressing
+```
+
+Implications:
+
+- The domain registry should stay focused on semantic/domain lookup for the local unit
+- MQTT topic names and other transport addresses should not be stored directly in the domain registry by default
+- MQTT topics should remain actor-specific addressing, owned by the MQTT package or a future MQTT topic index
+- If topic generation spreads or the contract hardens, introduce a dedicated MQTT topic index built from domain entities and MQTT configuration
+- Global config projection should decide what each unit knows about, while actor-specific indexes decide how that local knowledge maps to transports

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,10 @@ require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/eclipse/paho.mqtt.golang v1.5.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.44.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,17 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2ISgCl2W7nE=
+github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=
+golang.org/x/net v0.44.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ var (
 
 type Root struct {
 	Sysfs         SysfsConfig          `yaml:"sysfs"`
+	MQTT          MQTTConfig           `yaml:"mqtt"`
 	DigitalInputs []DigitalInputConfig `yaml:"digital_inputs"`
 	PushButtons   []PushButtonConfig   `yaml:"push_buttons"`
 	Lights        []LightConfig        `yaml:"lights"`
@@ -29,6 +30,17 @@ type Root struct {
 
 type SysfsConfig struct {
 	Root string `yaml:"root"`
+}
+
+type MQTTConfig struct {
+	Enabled     bool   `yaml:"enabled"`
+	Host        string `yaml:"host"`
+	Port        int    `yaml:"port"`
+	ClientID    string `yaml:"client_id"`
+	Username    string `yaml:"username"`
+	Password    string `yaml:"password"`
+	TopicPrefix string `yaml:"topic_prefix"`
+	UnitID      string `yaml:"unit_id"`
 }
 
 type DigitalInputConfig struct {
@@ -119,6 +131,7 @@ func Validate(f *Root) error {
 	errs = errors.Join(
 		errs,
 		validateSysfs(f.Sysfs),
+		validateMQTT(f.MQTT),
 		inputErr,
 		buttonErr,
 		relayErr,
@@ -131,6 +144,26 @@ func Validate(f *Root) error {
 
 func validateSysfs(sysfs SysfsConfig) error {
 	return validateRequiredField("sysfs.root", sysfs.Root)
+}
+
+func validateMQTT(mqtt MQTTConfig) error {
+	if !mqtt.Enabled {
+		return nil
+	}
+
+	var portErr error
+	if mqtt.Port < 1 || mqtt.Port > 65535 {
+		portErr = fmt.Errorf("mqtt.port: must be between 1 and 65535")
+	}
+
+	return errors.Join(
+		validateRequiredField("mqtt.host", mqtt.Host),
+		portErr,
+		validateRequiredField("mqtt.client_id", mqtt.ClientID),
+		validateOptionalField("mqtt.username", mqtt.Username),
+		validateTopicPrefix("mqtt.topic_prefix", mqtt.TopicPrefix),
+		validateID("mqtt.unit_id", mqtt.UnitID),
+	)
 }
 
 func validateDigitalInputs(inputs []DigitalInputConfig) (map[string]struct{}, error) {
@@ -353,6 +386,26 @@ func validateRequiredField(field string, value string) error {
 	}
 
 	return validateNoOuterWhitespace(field, value)
+}
+
+func validateOptionalField(field string, value string) error {
+	if value == "" {
+		return nil
+	}
+
+	return validateNoOuterWhitespace(field, value)
+}
+
+func validateTopicPrefix(field string, value string) error {
+	if err := validateRequiredField(field, value); err != nil {
+		return err
+	}
+
+	if strings.Contains(value, "//") || strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") {
+		return fmt.Errorf("%s: must be a relative MQTT topic prefix without empty segments", field)
+	}
+
+	return nil
 }
 
 func validatePattern(field string, value string, pattern *regexp.Regexp, label string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,6 +71,51 @@ func TestValidate(t *testing.T) {
 			message: "sysfs.root: must not have leading or trailing whitespace",
 		},
 		{
+			name: "requires enabled MQTT host",
+			file: Root{
+				Sysfs:  SysfsConfig{Root: "/tmp"},
+				MQTT:   validMQTTConfigWithHost(""),
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "ro_3_14"}},
+			},
+			message: "mqtt.host: required",
+		},
+		{
+			name: "rejects enabled MQTT port below range",
+			file: Root{
+				Sysfs:  SysfsConfig{Root: "/tmp"},
+				MQTT:   validMQTTConfigWithPort(0),
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "ro_3_14"}},
+			},
+			message: "mqtt.port: must be between 1 and 65535",
+		},
+		{
+			name: "rejects enabled MQTT port above range",
+			file: Root{
+				Sysfs:  SysfsConfig{Root: "/tmp"},
+				MQTT:   validMQTTConfigWithPort(65536),
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "ro_3_14"}},
+			},
+			message: "mqtt.port: must be between 1 and 65535",
+		},
+		{
+			name: "rejects enabled MQTT topic prefix with empty segments",
+			file: Root{
+				Sysfs:  SysfsConfig{Root: "/tmp"},
+				MQTT:   validMQTTConfigWithTopicPrefix("nest//controller"),
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "ro_3_14"}},
+			},
+			message: "mqtt.topic_prefix: must be a relative MQTT topic prefix without empty segments",
+		},
+		{
+			name: "rejects whitespace padded MQTT username",
+			file: Root{
+				Sysfs:  SysfsConfig{Root: "/tmp"},
+				MQTT:   validMQTTConfigWithUsername(" user "),
+				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "ro_3_14"}},
+			},
+			message: "mqtt.username: must not have leading or trailing whitespace",
+		},
+		{
 			name: "rejects duplicate digital input ids",
 			file: Root{
 				Sysfs: SysfsConfig{Root: "/tmp"},
@@ -222,6 +267,7 @@ func TestValidate(t *testing.T) {
 func TestValidateAcceptsValidFile(t *testing.T) {
 	file := Root{
 		Sysfs: SysfsConfig{Root: "/tmp"},
+		MQTT:  validMQTTConfig(),
 		DigitalInputs: []DigitalInputConfig{
 			{ID: "office_button_input", Device: "di_3_16"},
 		},
@@ -240,6 +286,39 @@ func TestValidateAcceptsValidFile(t *testing.T) {
 	}
 
 	require.NoError(t, Validate(&file))
+}
+
+func validMQTTConfig() MQTTConfig {
+	return validMQTTConfigWithPort(1883)
+}
+
+func validMQTTConfigWithPort(port int) MQTTConfig {
+	return MQTTConfig{
+		Enabled:     true,
+		Host:        "localhost",
+		Port:        port,
+		ClientID:    "nest-controller-1",
+		TopicPrefix: "nest",
+		UnitID:      "controller_1",
+	}
+}
+
+func validMQTTConfigWithTopicPrefix(topicPrefix string) MQTTConfig {
+	mqtt := validMQTTConfig()
+	mqtt.TopicPrefix = topicPrefix
+	return mqtt
+}
+
+func validMQTTConfigWithHost(host string) MQTTConfig {
+	mqtt := validMQTTConfig()
+	mqtt.Host = host
+	return mqtt
+}
+
+func validMQTTConfigWithUsername(username string) MQTTConfig {
+	mqtt := validMQTTConfig()
+	mqtt.Username = username
+	return mqtt
 }
 
 func writeTestFile(t *testing.T, path string, content string) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/mhemeryck/nest/internal/controller/event"
+	"github.com/mhemeryck/nest/internal/mqtt"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
@@ -12,11 +14,29 @@ func Run(
 	ctx context.Context,
 	index *registry.Index,
 	sysfsCommands chan<- sysfs.Command,
+	mqttCommands chan<- mqtt.Command,
+	mqttTopics mqtt.Topics,
 	stateChanges <-chan sysfs.StateChange,
 	done chan<- struct{},
 ) {
 	defer close(done)
+	semanticEvents := make(chan event.Event, 32)
+	normalizerDone := make(chan struct{})
+	go normalizeStateChanges(ctx, index, stateChanges, semanticEvents, normalizerDone)
 
+	dispatchEvents(ctx, index, sysfsCommands, mqttCommands, mqttTopics, semanticEvents)
+	<-normalizerDone
+}
+
+func normalizeStateChanges(
+	ctx context.Context,
+	index *registry.Index,
+	stateChanges <-chan sysfs.StateChange,
+	semanticEvents chan<- event.Event,
+	done chan<- struct{},
+) {
+	defer close(done)
+	defer close(semanticEvents)
 	for {
 		select {
 		case <-ctx.Done():
@@ -26,16 +46,40 @@ func Run(
 				return
 			}
 
-			handleSysfsStateChange(ctx, index, sysfsCommands, stateChange)
+			handleSysfsStateChange(ctx, index, semanticEvents, stateChange)
 		}
 	}
 }
 
-func handleSysfsStateChange(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, stateChange sysfs.StateChange) {
-	pushButtonEvents, handled := pushButtonEventsFromStateChange(index, stateChange)
+func dispatchEvents(
+	ctx context.Context,
+	index *registry.Index,
+	sysfsCommands chan<- sysfs.Command,
+	mqttCommands chan<- mqtt.Command,
+	mqttTopics mqtt.Topics,
+	semanticEvents <-chan event.Event,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case semanticEvent, ok := <-semanticEvents:
+			if !ok {
+				return
+			}
+
+			dispatchEvent(ctx, index, sysfsCommands, mqttCommands, mqttTopics, semanticEvent)
+		}
+	}
+}
+
+func handleSysfsStateChange(ctx context.Context, index *registry.Index, semanticEvents chan<- event.Event, stateChange sysfs.StateChange) {
+	events, handled := semanticEventsFromStateChange(index, stateChange)
 	if handled {
-		for _, pushButtonEvent := range pushButtonEvents {
-			dispatchEvent(ctx, index, sysfsCommands, pushButtonEvent)
+		for _, semanticEvent := range events {
+			if !publishSemanticEvent(ctx, semanticEvents, semanticEvent) {
+				return
+			}
 		}
 		return
 	}
@@ -53,4 +97,13 @@ func handleSysfsStateChange(ctx context.Context, index *registry.Index, sysfsCom
 		"rising",
 		stateChange.IsRising,
 	)
+}
+
+func publishSemanticEvent(ctx context.Context, semanticEvents chan<- event.Event, semanticEvent event.Event) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case semanticEvents <- semanticEvent:
+		return true
+	}
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -46,7 +46,7 @@ func normalizeStateChanges(
 				return
 			}
 
-			handleSysfsStateChange(ctx, index, semanticEvents, stateChange)
+			normalizeStateChange(ctx, index, semanticEvents, stateChange)
 		}
 	}
 }
@@ -73,7 +73,7 @@ func dispatchEvents(
 	}
 }
 
-func handleSysfsStateChange(ctx context.Context, index *registry.Index, semanticEvents chan<- event.Event, stateChange sysfs.StateChange) {
+func normalizeStateChange(ctx context.Context, index *registry.Index, semanticEvents chan<- event.Event, stateChange sysfs.StateChange) {
 	events, handled := semanticEventsFromStateChange(index, stateChange)
 	if handled {
 		for _, semanticEvent := range events {
@@ -84,6 +84,10 @@ func handleSysfsStateChange(ctx context.Context, index *registry.Index, semantic
 		return
 	}
 
+	logUnmappedStateChange(stateChange)
+}
+
+func logUnmappedStateChange(stateChange sysfs.StateChange) {
 	slog.Info(
 		"state change",
 		"identifier",

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -101,7 +101,7 @@ func TestHandleStateChangePublishesMappedInputAndButtonState(t *testing.T) {
 	topics := mqtt.NewTopics("nest", "controller_1")
 	semanticEvents := make(chan event.Event, 2)
 
-	handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
+	normalizeStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
 		Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
 		OldValue: sysfs.Off,
 		NewValue: sysfs.On,
@@ -135,7 +135,7 @@ func TestHandleStateChangePublishesMappedRelayState(t *testing.T) {
 	topics := mqtt.NewTopics("nest", "controller_1")
 	semanticEvents := make(chan event.Event, 1)
 
-	handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
+	normalizeStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
 		Device:   sysfs.Device{Identifier: "ro_3_14", Path: "/sys/ro_3_14/ro_value"},
 		OldValue: sysfs.Off,
 		NewValue: sysfs.On,
@@ -155,7 +155,7 @@ func TestHandleStateChangeLogsRawStateChangeForUnknownDevice(t *testing.T) {
 	semanticEvents := make(chan event.Event, 1)
 
 	logs := captureLogs(t, func() {
-		handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
+		normalizeStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
 			Device:   sysfs.Device{Identifier: "ro_3_14", Path: "/sys/ro_3_14/ro_value"},
 			OldValue: sysfs.Off,
 			NewValue: sysfs.On,
@@ -178,7 +178,7 @@ func TestHandleStateChangeLogsPushButtonRelease(t *testing.T) {
 	semanticEvents := make(chan event.Event, 2)
 
 	logs := captureLogs(t, func() {
-		handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
+		normalizeStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
 			Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
 			OldValue: sysfs.On,
 			NewValue: sysfs.Off,
@@ -208,7 +208,7 @@ func TestHandleStateChangeDoesNotBlockCommandSendAfterCancellation(t *testing.T)
 
 	go func() {
 		defer close(done)
-		handleSysfsStateChange(ctx, index, semanticEvents, sysfs.StateChange{
+		normalizeStateChange(ctx, index, semanticEvents, sysfs.StateChange{
 			Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
 			OldValue: sysfs.Off,
 			NewValue: sysfs.On,

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -158,6 +158,16 @@ func TestHandleStateChangePublishesMappedRelayAndLightState(t *testing.T) {
 	assert.True(t, lightCommand.Publish.Retain)
 }
 
+func TestPublishMQTTDoesNotBlockWhenCommandChannelIsFull(t *testing.T) {
+	commands := make(chan mqtt.Command, 1)
+	commands <- mqtt.PublishCommand(mqtt.PublishMessage{Topic: "nest/full"})
+
+	published := publishMQTT(t.Context(), commands, mqtt.PublishMessage{Topic: "nest/dropped"})
+
+	assert.False(t, published)
+	assert.Len(t, commands, 1)
+}
+
 func TestHandleStateChangeLogsRawStateChangeForUnknownDevice(t *testing.T) {
 	index := registry.Build(&entity.Root{})
 	semanticEvents := make(chan event.Event, 1)

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mhemeryck/nest/internal/controller/event"
 	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/mqtt"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +24,7 @@ func TestRunReturnsOnSignal(t *testing.T) {
 	stateChanges := make(chan sysfs.StateChange)
 	commands := make(chan sysfs.Command)
 	done := make(chan struct{})
-	go Run(ctx, index, commands, stateChanges, done)
+	go Run(ctx, index, commands, nil, mqtt.Topics{}, stateChanges, done)
 
 	cancel()
 
@@ -39,7 +41,7 @@ func TestRunReturnsWhenPollEventsClose(t *testing.T) {
 	stateChanges := make(chan sysfs.StateChange)
 	commands := make(chan sysfs.Command)
 	done := make(chan struct{})
-	go Run(ctx, index, commands, stateChanges, done)
+	go Run(ctx, index, commands, nil, mqtt.Topics{}, stateChanges, done)
 
 	close(stateChanges)
 
@@ -50,7 +52,7 @@ func TestRunReturnsWhenPollEventsClose(t *testing.T) {
 	}
 }
 
-func TestHandleStateChangeTogglesLightRelay(t *testing.T) {
+func TestDispatchPushButtonEventTogglesLightRelay(t *testing.T) {
 	relayPath := filepath.Join(t.TempDir(), "ro_value")
 	require.NoError(t, os.WriteFile(relayPath, []byte("0\n"), 0o644))
 
@@ -62,39 +64,98 @@ func TestHandleStateChangeTogglesLightRelay(t *testing.T) {
 		Bindings:      []entity.Binding{{Button: entity.PushButtonID("office_button"), Light: entity.LightID("office_light"), Action: entity.LightActionToggle}},
 	})
 	commands := make(chan sysfs.Command, 1)
-	commandDone := make(chan struct{})
-	go func() {
-		defer close(commandDone)
-		cmd := <-commands
-		require.Equal(t, sysfs.ToggleCommand, cmd.Kind)
-		require.Equal(t, "ro_3_14", cmd.DeviceID)
-		require.NoError(t, os.WriteFile(relayPath, []byte("1\n"), 0o644))
-	}()
 
 	logs := captureLogs(t, func() {
-		handleSysfsStateChange(t.Context(), index, commands, sysfs.StateChange{
-			Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
-			OldValue: sysfs.Off,
-			NewValue: sysfs.On,
-			IsRising: true,
+		dispatchEvent(t.Context(), index, commands, nil, mqtt.Topics{}, event.Event{
+			Kind: event.PushButtonPressedKind,
+			PushButton: &event.PushButton{
+				ButtonID: entity.PushButtonID("office_button"),
+				Name:     "Office button",
+			},
 		})
 	})
 
 	assert.Contains(t, logs, "push button event")
 	assert.Contains(t, logs, "light event")
 	assert.Contains(t, logs, "light toggled")
-	<-commandDone
+	cmd := <-commands
+	require.Equal(t, sysfs.ToggleCommand, cmd.Kind)
+	require.Equal(t, "ro_3_14", cmd.DeviceID)
+	require.NoError(t, os.WriteFile(relayPath, []byte("1\n"), 0o644))
 
 	data, err := os.ReadFile(relayPath)
 	require.NoError(t, err)
 	assert.Equal(t, "1\n", string(data))
 }
 
+func TestHandleStateChangePublishesMappedInputAndButtonState(t *testing.T) {
+	index := registry.Build(&entity.Root{
+		DigitalInputs: []entity.DigitalInput{{ID: entity.DigitalInputID("office_button_input"), SysfsDevice: entity.SysfsDeviceID("di_3_16")}},
+		PushButtons:   []entity.PushButton{{ID: entity.PushButtonID("office_button"), Name: "Office button", Input: entity.DigitalInputID("office_button_input")}},
+		Lights:        []entity.Light{{ID: entity.LightID("office_light"), Name: "Office light", Relay: entity.RelayID("office_light_relay")}},
+		Relays:        []entity.Relay{{ID: entity.RelayID("office_light_relay"), Name: "Office light relay", SysfsDevice: entity.SysfsDeviceID("ro_3_14")}},
+		Bindings:      []entity.Binding{{Button: entity.PushButtonID("office_button"), Light: entity.LightID("office_light"), Action: entity.LightActionToggle}},
+	})
+	sysfsCommands := make(chan sysfs.Command, 1)
+	mqttCommands := make(chan mqtt.Command, 2)
+	topics := mqtt.NewTopics("nest", "controller_1")
+	semanticEvents := make(chan event.Event, 2)
+
+	handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
+		Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
+		OldValue: sysfs.Off,
+		NewValue: sysfs.On,
+		IsRising: true,
+	})
+	dispatchEvent(t.Context(), index, sysfsCommands, mqttCommands, topics, <-semanticEvents)
+	dispatchEvent(t.Context(), index, sysfsCommands, mqttCommands, topics, <-semanticEvents)
+
+	inputCommand := <-mqttCommands
+	assert.Equal(t, mqtt.PublishCommandKind, inputCommand.Kind)
+	assert.Equal(t, "nest/units/controller_1/digital_inputs/office_button_input/state", inputCommand.Publish.Topic)
+	assert.JSONEq(t, `{"input_id":"office_button_input","sysfs_device":"di_3_16","value":1}`, string(inputCommand.Publish.Payload))
+	assert.True(t, inputCommand.Publish.Retain)
+
+	buttonCommand := <-mqttCommands
+	assert.Equal(t, mqtt.PublishCommandKind, buttonCommand.Kind)
+	assert.Equal(t, "nest/units/controller_1/push_buttons/office_button/state", buttonCommand.Publish.Topic)
+	assert.JSONEq(t, `{"button_id":"office_button","name":"Office button","state":"pressed"}`, string(buttonCommand.Publish.Payload))
+	assert.False(t, buttonCommand.Publish.Retain)
+
+	sysfsCommand := <-sysfsCommands
+	assert.Equal(t, sysfs.ToggleCommand, sysfsCommand.Kind)
+	assert.Equal(t, "ro_3_14", sysfsCommand.DeviceID)
+}
+
+func TestHandleStateChangePublishesMappedRelayState(t *testing.T) {
+	index := registry.Build(&entity.Root{
+		Relays: []entity.Relay{{ID: entity.RelayID("office_light_relay"), Name: "Office light relay", SysfsDevice: entity.SysfsDeviceID("ro_3_14")}},
+	})
+	mqttCommands := make(chan mqtt.Command, 1)
+	topics := mqtt.NewTopics("nest", "controller_1")
+	semanticEvents := make(chan event.Event, 1)
+
+	handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
+		Device:   sysfs.Device{Identifier: "ro_3_14", Path: "/sys/ro_3_14/ro_value"},
+		OldValue: sysfs.Off,
+		NewValue: sysfs.On,
+		IsRising: true,
+	})
+	dispatchEvent(t.Context(), index, nil, mqttCommands, topics, <-semanticEvents)
+
+	command := <-mqttCommands
+	assert.Equal(t, mqtt.PublishCommandKind, command.Kind)
+	assert.Equal(t, "nest/units/controller_1/relays/office_light_relay/state", command.Publish.Topic)
+	assert.JSONEq(t, `{"relay_id":"office_light_relay","name":"Office light relay","sysfs_device":"ro_3_14","value":1}`, string(command.Publish.Payload))
+	assert.True(t, command.Publish.Retain)
+}
+
 func TestHandleStateChangeLogsRawStateChangeForUnknownDevice(t *testing.T) {
 	index := registry.Build(&entity.Root{})
+	semanticEvents := make(chan event.Event, 1)
 
 	logs := captureLogs(t, func() {
-		handleSysfsStateChange(t.Context(), index, nil, sysfs.StateChange{
+		handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
 			Device:   sysfs.Device{Identifier: "ro_3_14", Path: "/sys/ro_3_14/ro_value"},
 			OldValue: sysfs.Off,
 			NewValue: sysfs.On,
@@ -114,14 +175,17 @@ func TestHandleStateChangeLogsPushButtonRelease(t *testing.T) {
 		Lights:        []entity.Light{{ID: entity.LightID("office_light"), Name: "Office light", Relay: entity.RelayID("office_light_relay")}},
 		Bindings:      []entity.Binding{{Button: entity.PushButtonID("office_button"), Light: entity.LightID("office_light"), Action: entity.LightActionToggle}},
 	})
+	semanticEvents := make(chan event.Event, 2)
 
 	logs := captureLogs(t, func() {
-		handleSysfsStateChange(t.Context(), index, nil, sysfs.StateChange{
+		handleSysfsStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
 			Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
 			OldValue: sysfs.On,
 			NewValue: sysfs.Off,
 			IsRising: false,
 		})
+		dispatchEvent(t.Context(), index, nil, nil, mqtt.Topics{}, <-semanticEvents)
+		dispatchEvent(t.Context(), index, nil, nil, mqtt.Topics{}, <-semanticEvents)
 	})
 
 	assert.Contains(t, logs, "push button event")
@@ -139,12 +203,12 @@ func TestHandleStateChangeDoesNotBlockCommandSendAfterCancellation(t *testing.T)
 		Relays:        []entity.Relay{{ID: entity.RelayID("office_light_relay"), Name: "Office light relay", SysfsDevice: entity.SysfsDeviceID("ro_3_14")}},
 		Bindings:      []entity.Binding{{Button: entity.PushButtonID("office_button"), Light: entity.LightID("office_light"), Action: entity.LightActionToggle}},
 	})
-	commands := make(chan sysfs.Command)
+	semanticEvents := make(chan event.Event)
 	done := make(chan struct{})
 
 	go func() {
 		defer close(done)
-		handleSysfsStateChange(ctx, index, commands, sysfs.StateChange{
+		handleSysfsStateChange(ctx, index, semanticEvents, sysfs.StateChange{
 			Device:   sysfs.Device{Identifier: "di_3_16", Path: "/sys/di_3_16/di_value"},
 			OldValue: sysfs.Off,
 			NewValue: sysfs.On,

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -127,13 +127,14 @@ func TestHandleStateChangePublishesMappedInputAndButtonState(t *testing.T) {
 	assert.Equal(t, "ro_3_14", sysfsCommand.DeviceID)
 }
 
-func TestHandleStateChangePublishesMappedRelayState(t *testing.T) {
+func TestHandleStateChangePublishesMappedRelayAndLightState(t *testing.T) {
 	index := registry.Build(&entity.Root{
+		Lights: []entity.Light{{ID: entity.LightID("office_light"), Name: "Office light", Relay: entity.RelayID("office_light_relay")}},
 		Relays: []entity.Relay{{ID: entity.RelayID("office_light_relay"), Name: "Office light relay", SysfsDevice: entity.SysfsDeviceID("ro_3_14")}},
 	})
-	mqttCommands := make(chan mqtt.Command, 1)
+	mqttCommands := make(chan mqtt.Command, 2)
 	topics := mqtt.NewTopics("nest", "controller_1")
-	semanticEvents := make(chan event.Event, 1)
+	semanticEvents := make(chan event.Event, 2)
 
 	normalizeStateChange(t.Context(), index, semanticEvents, sysfs.StateChange{
 		Device:   sysfs.Device{Identifier: "ro_3_14", Path: "/sys/ro_3_14/ro_value"},
@@ -142,12 +143,19 @@ func TestHandleStateChangePublishesMappedRelayState(t *testing.T) {
 		IsRising: true,
 	})
 	dispatchEvent(t.Context(), index, nil, mqttCommands, topics, <-semanticEvents)
+	dispatchEvent(t.Context(), index, nil, mqttCommands, topics, <-semanticEvents)
 
-	command := <-mqttCommands
-	assert.Equal(t, mqtt.PublishCommandKind, command.Kind)
-	assert.Equal(t, "nest/units/controller_1/relays/office_light_relay/state", command.Publish.Topic)
-	assert.JSONEq(t, `{"relay_id":"office_light_relay","name":"Office light relay","sysfs_device":"ro_3_14","value":1}`, string(command.Publish.Payload))
-	assert.True(t, command.Publish.Retain)
+	relayCommand := <-mqttCommands
+	assert.Equal(t, mqtt.PublishCommandKind, relayCommand.Kind)
+	assert.Equal(t, "nest/units/controller_1/relays/office_light_relay/state", relayCommand.Publish.Topic)
+	assert.JSONEq(t, `{"relay_id":"office_light_relay","name":"Office light relay","sysfs_device":"ro_3_14","value":1}`, string(relayCommand.Publish.Payload))
+	assert.True(t, relayCommand.Publish.Retain)
+
+	lightCommand := <-mqttCommands
+	assert.Equal(t, mqtt.PublishCommandKind, lightCommand.Kind)
+	assert.Equal(t, "nest/units/controller_1/lights/office_light/state", lightCommand.Publish.Topic)
+	assert.JSONEq(t, `{"light_id":"office_light","name":"Office light","relay_id":"office_light_relay","value":1}`, string(lightCommand.Publish.Payload))
+	assert.True(t, lightCommand.Publish.Retain)
 }
 
 func TestHandleStateChangeLogsRawStateChangeForUnknownDevice(t *testing.T) {

--- a/internal/controller/dispatch.go
+++ b/internal/controller/dispatch.go
@@ -6,20 +6,40 @@ import (
 
 	"github.com/mhemeryck/nest/internal/controller/event"
 	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/mqtt"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
-func dispatchEvent(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, busEvent event.Event) {
+func dispatchEvent(
+	ctx context.Context,
+	index *registry.Index,
+	sysfsCommands chan<- sysfs.Command,
+	mqttCommands chan<- mqtt.Command,
+	mqttTopics mqtt.Topics,
+	busEvent event.Event,
+) {
 	switch busEvent.Kind {
+	case event.DigitalInputStateKind:
+		publishDigitalInputState(ctx, mqttCommands, mqttTopics, *busEvent.DigitalInput)
 	case event.PushButtonPressedKind, event.PushButtonReleasedKind:
-		handlePushButtonEvent(ctx, index, sysfsCommands, busEvent.Kind, *busEvent.PushButton)
+		handlePushButtonEvent(ctx, index, sysfsCommands, mqttCommands, mqttTopics, busEvent.Kind, *busEvent.PushButton)
+	case event.RelayStateKind:
+		publishRelayState(ctx, mqttCommands, mqttTopics, *busEvent.Relay)
 	case event.LightKind:
 		dispatchLightEvent(ctx, index, sysfsCommands, *busEvent.Light)
 	}
 }
 
-func handlePushButtonEvent(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, eventKind event.Kind, pushButton event.PushButton) {
+func handlePushButtonEvent(
+	ctx context.Context,
+	index *registry.Index,
+	sysfsCommands chan<- sysfs.Command,
+	mqttCommands chan<- mqtt.Command,
+	mqttTopics mqtt.Topics,
+	eventKind event.Kind,
+	pushButton event.PushButton,
+) {
 	slog.Info(
 		"push button event",
 		"button_id",
@@ -29,13 +49,14 @@ func handlePushButtonEvent(ctx context.Context, index *registry.Index, sysfsComm
 		"event_kind",
 		eventKind,
 	)
+	publishPushButtonState(ctx, mqttCommands, mqttTopics, eventKind, pushButton)
 
 	if eventKind != event.PushButtonPressedKind {
 		return
 	}
 
 	for _, lightEvent := range lightEventsFromPushButton(index, pushButton) {
-		dispatchEvent(ctx, index, sysfsCommands, lightEvent)
+		dispatchEvent(ctx, index, sysfsCommands, mqttCommands, mqttTopics, lightEvent)
 	}
 }
 

--- a/internal/controller/dispatch.go
+++ b/internal/controller/dispatch.go
@@ -19,17 +19,49 @@ func dispatchEvent(
 	mqttTopics mqtt.Topics,
 	busEvent event.Event,
 ) {
+	logSemanticEvent(busEvent)
+	dispatchSysfsCommand(ctx, index, sysfsCommands, busEvent)
+	dispatchMQTTCommand(ctx, mqttCommands, mqttTopics, busEvent)
+}
+
+func dispatchSysfsCommand(ctx context.Context, index *registry.Index, commands chan<- sysfs.Command, busEvent event.Event) {
+	switch busEvent.Kind {
+	case event.PushButtonPressedKind:
+		dispatchLightEventsFromPushButton(ctx, index, commands, *busEvent.PushButton)
+	case event.LightKind:
+		dispatchLightEvent(ctx, index, commands, *busEvent.Light)
+	}
+}
+
+func dispatchMQTTCommand(ctx context.Context, commands chan<- mqtt.Command, topics mqtt.Topics, busEvent event.Event) {
 	switch busEvent.Kind {
 	case event.DigitalInputStateKind:
-		publishDigitalInputState(ctx, mqttCommands, mqttTopics, *busEvent.DigitalInput)
+		publishDigitalInputState(ctx, commands, topics, *busEvent.DigitalInput)
+	case event.PushButtonPressedKind, event.PushButtonReleasedKind:
+		publishPushButtonState(ctx, commands, topics, busEvent.Kind, *busEvent.PushButton)
+	case event.RelayStateKind:
+		publishRelayState(ctx, commands, topics, *busEvent.Relay)
+	}
+}
+
+func dispatchLightEventsFromPushButton(
+	ctx context.Context,
+	index *registry.Index,
+	sysfsCommands chan<- sysfs.Command,
+	pushButton event.PushButton,
+) {
+	for _, lightEvent := range lightEventsFromPushButton(index, pushButton) {
+		logSemanticEvent(lightEvent)
+		dispatchSysfsCommand(ctx, index, sysfsCommands, lightEvent)
+	}
+}
+
+func logSemanticEvent(busEvent event.Event) {
+	switch busEvent.Kind {
 	case event.PushButtonPressedKind, event.PushButtonReleasedKind:
 		logPushButtonEvent(busEvent.Kind, *busEvent.PushButton)
-		publishPushButtonState(ctx, mqttCommands, mqttTopics, busEvent.Kind, *busEvent.PushButton)
-		dispatchLightEventsFromPushButton(ctx, index, sysfsCommands, mqttCommands, mqttTopics, busEvent.Kind, *busEvent.PushButton)
-	case event.RelayStateKind:
-		publishRelayState(ctx, mqttCommands, mqttTopics, *busEvent.Relay)
 	case event.LightKind:
-		dispatchLightEvent(ctx, index, sysfsCommands, *busEvent.Light)
+		logLightEvent(*busEvent.Light)
 	}
 }
 
@@ -45,25 +77,16 @@ func logPushButtonEvent(eventKind event.Kind, pushButton event.PushButton) {
 	)
 }
 
-func dispatchLightEventsFromPushButton(
-	ctx context.Context,
-	index *registry.Index,
-	sysfsCommands chan<- sysfs.Command,
-	mqttCommands chan<- mqtt.Command,
-	mqttTopics mqtt.Topics,
-	eventKind event.Kind,
-	pushButton event.PushButton,
-) {
-	if eventKind != event.PushButtonPressedKind {
+func dispatchLightEvent(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, lightEvent event.Light) {
+	if lightEvent.Action != entity.LightActionToggle {
+		slog.Error("unsupported light action", "action", lightEvent.Action)
 		return
 	}
 
-	for _, lightEvent := range lightEventsFromPushButton(index, pushButton) {
-		dispatchEvent(ctx, index, sysfsCommands, mqttCommands, mqttTopics, lightEvent)
-	}
+	handleLightToggle(ctx, index, sysfsCommands, lightEvent)
 }
 
-func dispatchLightEvent(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, lightEvent event.Light) {
+func logLightEvent(lightEvent event.Light) {
 	slog.Info(
 		"light event",
 		"light_id",
@@ -73,11 +96,4 @@ func dispatchLightEvent(ctx context.Context, index *registry.Index, sysfsCommand
 		"action",
 		lightEvent.Action,
 	)
-
-	if lightEvent.Action != entity.LightActionToggle {
-		slog.Error("unsupported light action", "action", lightEvent.Action)
-		return
-	}
-
-	handleLightToggle(ctx, index, sysfsCommands, lightEvent)
 }

--- a/internal/controller/dispatch.go
+++ b/internal/controller/dispatch.go
@@ -23,7 +23,9 @@ func dispatchEvent(
 	case event.DigitalInputStateKind:
 		publishDigitalInputState(ctx, mqttCommands, mqttTopics, *busEvent.DigitalInput)
 	case event.PushButtonPressedKind, event.PushButtonReleasedKind:
-		handlePushButtonEvent(ctx, index, sysfsCommands, mqttCommands, mqttTopics, busEvent.Kind, *busEvent.PushButton)
+		logPushButtonEvent(busEvent.Kind, *busEvent.PushButton)
+		publishPushButtonState(ctx, mqttCommands, mqttTopics, busEvent.Kind, *busEvent.PushButton)
+		dispatchLightEventsFromPushButton(ctx, index, sysfsCommands, mqttCommands, mqttTopics, busEvent.Kind, *busEvent.PushButton)
 	case event.RelayStateKind:
 		publishRelayState(ctx, mqttCommands, mqttTopics, *busEvent.Relay)
 	case event.LightKind:
@@ -31,15 +33,7 @@ func dispatchEvent(
 	}
 }
 
-func handlePushButtonEvent(
-	ctx context.Context,
-	index *registry.Index,
-	sysfsCommands chan<- sysfs.Command,
-	mqttCommands chan<- mqtt.Command,
-	mqttTopics mqtt.Topics,
-	eventKind event.Kind,
-	pushButton event.PushButton,
-) {
+func logPushButtonEvent(eventKind event.Kind, pushButton event.PushButton) {
 	slog.Info(
 		"push button event",
 		"button_id",
@@ -49,8 +43,17 @@ func handlePushButtonEvent(
 		"event_kind",
 		eventKind,
 	)
-	publishPushButtonState(ctx, mqttCommands, mqttTopics, eventKind, pushButton)
+}
 
+func dispatchLightEventsFromPushButton(
+	ctx context.Context,
+	index *registry.Index,
+	sysfsCommands chan<- sysfs.Command,
+	mqttCommands chan<- mqtt.Command,
+	mqttTopics mqtt.Topics,
+	eventKind event.Kind,
+	pushButton event.PushButton,
+) {
 	if eventKind != event.PushButtonPressedKind {
 		return
 	}

--- a/internal/controller/dispatch.go
+++ b/internal/controller/dispatch.go
@@ -41,6 +41,8 @@ func dispatchMQTTCommand(ctx context.Context, commands chan<- mqtt.Command, topi
 		publishPushButtonState(ctx, commands, topics, busEvent.Kind, *busEvent.PushButton)
 	case event.RelayStateKind:
 		publishRelayState(ctx, commands, topics, *busEvent.Relay)
+	case event.LightStateKind:
+		publishLightState(ctx, commands, topics, *busEvent.LightState)
 	}
 }
 

--- a/internal/controller/event/event.go
+++ b/internal/controller/event/event.go
@@ -5,15 +5,25 @@ import "github.com/mhemeryck/nest/internal/entity"
 type Kind string
 
 const (
+	DigitalInputStateKind  Kind = "digital_input_state"
 	PushButtonPressedKind  Kind = "push_button_pressed"
 	PushButtonReleasedKind Kind = "push_button_released"
+	RelayStateKind         Kind = "relay_state"
 	LightKind              Kind = "light"
 )
 
 type Event struct {
-	Kind       Kind
-	PushButton *PushButton
-	Light      *Light
+	Kind         Kind
+	DigitalInput *DigitalInput
+	PushButton   *PushButton
+	Relay        *Relay
+	Light        *Light
+}
+
+type DigitalInput struct {
+	InputID     entity.DigitalInputID
+	SysfsDevice entity.SysfsDeviceID
+	Value       int
 }
 
 type PushButton struct {
@@ -25,4 +35,11 @@ type Light struct {
 	LightID entity.LightID
 	Name    string
 	Action  entity.LightAction
+}
+
+type Relay struct {
+	RelayID     entity.RelayID
+	Name        string
+	SysfsDevice entity.SysfsDeviceID
+	Value       int
 }

--- a/internal/controller/event/event.go
+++ b/internal/controller/event/event.go
@@ -9,6 +9,7 @@ const (
 	PushButtonPressedKind  Kind = "push_button_pressed"
 	PushButtonReleasedKind Kind = "push_button_released"
 	RelayStateKind         Kind = "relay_state"
+	LightStateKind         Kind = "light_state"
 	LightKind              Kind = "light"
 )
 
@@ -17,6 +18,7 @@ type Event struct {
 	DigitalInput *DigitalInput
 	PushButton   *PushButton
 	Relay        *Relay
+	LightState   *LightState
 	Light        *Light
 }
 
@@ -35,6 +37,13 @@ type Light struct {
 	LightID entity.LightID
 	Name    string
 	Action  entity.LightAction
+}
+
+type LightState struct {
+	LightID entity.LightID
+	Name    string
+	RelayID entity.RelayID
+	Value   int
 }
 
 type Relay struct {

--- a/internal/controller/mqtt.go
+++ b/internal/controller/mqtt.go
@@ -82,6 +82,9 @@ func publishMQTT(ctx context.Context, commands chan<- mqtt.Command, message mqtt
 		return false
 	case commands <- mqtt.PublishCommand(message):
 		return true
+	default:
+		slog.Warn("mqtt publish command dropped", "topic", message.Topic)
+		return false
 	}
 }
 

--- a/internal/controller/mqtt.go
+++ b/internal/controller/mqtt.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/mhemeryck/nest/internal/controller/event"
+	"github.com/mhemeryck/nest/internal/mqtt"
+)
+
+func publishDigitalInputState(ctx context.Context, commands chan<- mqtt.Command, topics mqtt.Topics, input event.DigitalInput) {
+	message, err := mqtt.DigitalInputStateMessage(topics, mqtt.DigitalInputObservation{
+		InputID:     input.InputID,
+		SysfsDevice: input.SysfsDevice,
+		Value:       input.Value,
+	})
+	if err != nil {
+		slog.Error("build mqtt digital input state failed", "input_id", input.InputID, "error", err)
+		return
+	}
+
+	publishMQTT(ctx, commands, message)
+}
+
+func publishPushButtonState(
+	ctx context.Context,
+	commands chan<- mqtt.Command,
+	topics mqtt.Topics,
+	eventKind event.Kind,
+	pushButton event.PushButton,
+) {
+	message, err := mqtt.PushButtonStateMessage(topics, mqtt.PushButtonObservation{
+		ButtonID: pushButton.ButtonID,
+		Name:     pushButton.Name,
+		State:    pushButtonState(eventKind),
+	})
+	if err != nil {
+		slog.Error("build mqtt push button state failed", "button_id", pushButton.ButtonID, "error", err)
+		return
+	}
+
+	publishMQTT(ctx, commands, message)
+}
+
+func publishRelayState(ctx context.Context, commands chan<- mqtt.Command, topics mqtt.Topics, relay event.Relay) {
+	message, err := mqtt.RelayStateMessage(topics, mqtt.RelayObservation{
+		RelayID:     relay.RelayID,
+		Name:        relay.Name,
+		SysfsDevice: relay.SysfsDevice,
+		Value:       relay.Value,
+	})
+	if err != nil {
+		slog.Error("build mqtt relay state failed", "relay_id", relay.RelayID, "error", err)
+		return
+	}
+
+	publishMQTT(ctx, commands, message)
+}
+
+func publishMQTT(ctx context.Context, commands chan<- mqtt.Command, message mqtt.PublishMessage) bool {
+	if commands == nil {
+		return false
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case commands <- mqtt.PublishCommand(message):
+		return true
+	}
+}
+
+func pushButtonState(eventKind event.Kind) string {
+	if eventKind == event.PushButtonPressedKind {
+		return "pressed"
+	}
+
+	return "released"
+}

--- a/internal/controller/mqtt.go
+++ b/internal/controller/mqtt.go
@@ -57,6 +57,21 @@ func publishRelayState(ctx context.Context, commands chan<- mqtt.Command, topics
 	publishMQTT(ctx, commands, message)
 }
 
+func publishLightState(ctx context.Context, commands chan<- mqtt.Command, topics mqtt.Topics, light event.LightState) {
+	message, err := mqtt.LightStateMessage(topics, mqtt.LightObservation{
+		LightID: light.LightID,
+		Name:    light.Name,
+		RelayID: light.RelayID,
+		Value:   light.Value,
+	})
+	if err != nil {
+		slog.Error("build mqtt light state failed", "light_id", light.LightID, "error", err)
+		return
+	}
+
+	publishMQTT(ctx, commands, message)
+}
+
 func publishMQTT(ctx context.Context, commands chan<- mqtt.Command, message mqtt.PublishMessage) bool {
 	if commands == nil {
 		return false

--- a/internal/controller/normalize.go
+++ b/internal/controller/normalize.go
@@ -33,6 +33,39 @@ func pushButtonEventsFromStateChange(index *registry.Index, stateChange sysfs.St
 	return buttonEvents, true
 }
 
+func semanticEventsFromStateChange(index *registry.Index, stateChange sysfs.StateChange) ([]event.Event, bool) {
+	deviceID := entity.SysfsDeviceID(stateChange.Device.Identifier)
+	if input, ok := registry.DigitalInputBySysfsDevice(index, deviceID); ok {
+		events := []event.Event{{
+			Kind: event.DigitalInputStateKind,
+			DigitalInput: &event.DigitalInput{
+				InputID:     input.ID,
+				SysfsDevice: input.SysfsDevice,
+				Value:       sysfs.PrintableValue(stateChange.NewValue),
+			},
+		}}
+
+		pushButtonEvents, _ := pushButtonEventsFromStateChange(index, stateChange)
+		events = append(events, pushButtonEvents...)
+
+		return events, true
+	}
+
+	if relay, ok := registry.RelayBySysfsDevice(index, deviceID); ok {
+		return []event.Event{{
+			Kind: event.RelayStateKind,
+			Relay: &event.Relay{
+				RelayID:     relay.ID,
+				Name:        relay.Name,
+				SysfsDevice: relay.SysfsDevice,
+				Value:       sysfs.PrintableValue(stateChange.NewValue),
+			},
+		}}, true
+	}
+
+	return nil, false
+}
+
 func lightEventsFromPushButton(index *registry.Index, pushButton event.PushButton) []event.Event {
 	bindings := registry.BindingsByButton(index, pushButton.ButtonID)
 	lightEvents := make([]event.Event, 0, len(bindings))

--- a/internal/controller/normalize.go
+++ b/internal/controller/normalize.go
@@ -52,7 +52,7 @@ func semanticEventsFromStateChange(index *registry.Index, stateChange sysfs.Stat
 	}
 
 	if relay, ok := registry.RelayBySysfsDevice(index, deviceID); ok {
-		return []event.Event{{
+		events := []event.Event{{
 			Kind: event.RelayStateKind,
 			Relay: &event.Relay{
 				RelayID:     relay.ID,
@@ -60,7 +60,21 @@ func semanticEventsFromStateChange(index *registry.Index, stateChange sysfs.Stat
 				SysfsDevice: relay.SysfsDevice,
 				Value:       sysfs.PrintableValue(stateChange.NewValue),
 			},
-		}}, true
+		}}
+
+		for _, light := range registry.LightsByRelay(index, relay.ID) {
+			events = append(events, event.Event{
+				Kind: event.LightStateKind,
+				LightState: &event.LightState{
+					LightID: light.ID,
+					Name:    light.Name,
+					RelayID: relay.ID,
+					Value:   sysfs.PrintableValue(stateChange.NewValue),
+				},
+			})
+		}
+
+		return events, true
 	}
 
 	return nil, false

--- a/internal/controller/normalize_test.go
+++ b/internal/controller/normalize_test.go
@@ -78,3 +78,27 @@ func TestLightEventsFromPushButton(t *testing.T) {
 	assert.Equal(t, "Office light", events[0].Light.Name)
 	assert.Equal(t, entity.LightActionToggle, events[0].Light.Action)
 }
+
+func TestSemanticEventsFromRelayStateChangeIncludesLightState(t *testing.T) {
+	index := registry.Build(&entity.Root{
+		Relays: []entity.Relay{{ID: entity.RelayID("office_light_relay"), Name: "Office light relay", SysfsDevice: entity.SysfsDeviceID("ro_3_14")}},
+		Lights: []entity.Light{{ID: entity.LightID("office_light"), Name: "Office light", Relay: entity.RelayID("office_light_relay")}},
+	})
+
+	events, handled := semanticEventsFromStateChange(index, sysfs.StateChange{
+		Device:   sysfs.Device{Identifier: "ro_3_14"},
+		OldValue: sysfs.Off,
+		NewValue: sysfs.On,
+		IsRising: true,
+	})
+
+	require.True(t, handled)
+	require.Len(t, events, 2)
+	assert.Equal(t, event.RelayStateKind, events[0].Kind)
+	assert.Equal(t, entity.RelayID("office_light_relay"), events[0].Relay.RelayID)
+	assert.Equal(t, 1, events[0].Relay.Value)
+	assert.Equal(t, event.LightStateKind, events[1].Kind)
+	assert.Equal(t, entity.LightID("office_light"), events[1].LightState.LightID)
+	assert.Equal(t, entity.RelayID("office_light_relay"), events[1].LightState.RelayID)
+	assert.Equal(t, 1, events[1].LightState.Value)
+}

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -15,11 +15,23 @@ const LightActionToggle LightAction = "toggle"
 
 type Root struct {
 	SysfsRoot     string
+	MQTT          MQTT
 	DigitalInputs []DigitalInput
 	PushButtons   []PushButton
 	Lights        []Light
 	Relays        []Relay
 	Bindings      []Binding
+}
+
+type MQTT struct {
+	Enabled     bool
+	Host        string
+	Port        int
+	ClientID    string
+	Username    string
+	Password    string
+	TopicPrefix string
+	UnitID      string
 }
 
 type DigitalInput struct {
@@ -58,6 +70,7 @@ func FromConfig(root *config.Root) *Root {
 
 	entities := &Root{
 		SysfsRoot:     root.Sysfs.Root,
+		MQTT:          mqttFromConfig(root.MQTT),
 		DigitalInputs: make([]DigitalInput, 0, len(root.DigitalInputs)),
 		PushButtons:   make([]PushButton, 0, len(root.PushButtons)),
 		Lights:        make([]Light, 0, len(root.Lights)),
@@ -105,4 +118,17 @@ func FromConfig(root *config.Root) *Root {
 	}
 
 	return entities
+}
+
+func mqttFromConfig(mqtt config.MQTTConfig) MQTT {
+	return MQTT{
+		Enabled:     mqtt.Enabled,
+		Host:        mqtt.Host,
+		Port:        mqtt.Port,
+		ClientID:    mqtt.ClientID,
+		Username:    mqtt.Username,
+		Password:    mqtt.Password,
+		TopicPrefix: mqtt.TopicPrefix,
+		UnitID:      mqtt.UnitID,
+	}
 }

--- a/internal/entity/entity_test.go
+++ b/internal/entity/entity_test.go
@@ -11,6 +11,16 @@ import (
 func TestFromConfig(t *testing.T) {
 	root := FromConfig(&config.Root{
 		Sysfs: config.SysfsConfig{Root: "test/fixtures"},
+		MQTT: config.MQTTConfig{
+			Enabled:     true,
+			Host:        "localhost",
+			Port:        1883,
+			ClientID:    "nest-controller-1",
+			Username:    "nest",
+			Password:    "secret",
+			TopicPrefix: "nest",
+			UnitID:      "controller_1",
+		},
 		DigitalInputs: []config.DigitalInputConfig{{
 			ID:     "office_button_input",
 			Device: "di_3_16",
@@ -39,6 +49,16 @@ func TestFromConfig(t *testing.T) {
 
 	require.NotNil(t, root)
 	assert.Equal(t, "test/fixtures", root.SysfsRoot)
+	assert.Equal(t, MQTT{
+		Enabled:     true,
+		Host:        "localhost",
+		Port:        1883,
+		ClientID:    "nest-controller-1",
+		Username:    "nest",
+		Password:    "secret",
+		TopicPrefix: "nest",
+		UnitID:      "controller_1",
+	}, root.MQTT)
 	assert.Equal(t, []DigitalInput{{ID: DigitalInputID("office_button_input"), SysfsDevice: SysfsDeviceID("di_3_16")}}, root.DigitalInputs)
 	assert.Equal(t, []PushButton{{ID: PushButtonID("office_button"), Name: "Office button", Input: DigitalInputID("office_button_input")}}, root.PushButtons)
 	assert.Equal(t, []Light{{ID: LightID("office_light"), Name: "Office light", Relay: RelayID("office_light_relay")}}, root.Lights)

--- a/internal/mqtt/actor.go
+++ b/internal/mqtt/actor.go
@@ -1,0 +1,69 @@
+package mqtt
+
+type CommandKind string
+
+const PublishCommandKind CommandKind = "publish"
+
+type Command struct {
+	Kind    CommandKind
+	Publish PublishMessage
+}
+
+type EventKind string
+
+const (
+	ConnectedEventKind    EventKind = "connected"
+	ConnectFailedKind     EventKind = "connect_failed"
+	DisconnectedEventKind EventKind = "disconnected"
+	PublishedEventKind    EventKind = "published"
+	PublishFailedKind     EventKind = "publish_failed"
+)
+
+type Event struct {
+	Kind    EventKind
+	Publish PublishMessage
+	Error   string
+}
+
+func PublishCommand(message PublishMessage) Command {
+	return Command{
+		Kind:    PublishCommandKind,
+		Publish: message,
+	}
+}
+
+func ConnectedEvent() Event {
+	return Event{Kind: ConnectedEventKind}
+}
+
+func ConnectFailedEvent(err error) Event {
+	event := Event{Kind: ConnectFailedKind}
+	if err != nil {
+		event.Error = err.Error()
+	}
+
+	return event
+}
+
+func DisconnectedEvent() Event {
+	return Event{Kind: DisconnectedEventKind}
+}
+
+func PublishedEvent(message PublishMessage) Event {
+	return Event{
+		Kind:    PublishedEventKind,
+		Publish: message,
+	}
+}
+
+func PublishFailedEvent(message PublishMessage, err error) Event {
+	event := Event{
+		Kind:    PublishFailedKind,
+		Publish: message,
+	}
+	if err != nil {
+		event.Error = err.Error()
+	}
+
+	return event
+}

--- a/internal/mqtt/actor_test.go
+++ b/internal/mqtt/actor_test.go
@@ -1,0 +1,29 @@
+package mqtt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublishCommand(t *testing.T) {
+	message := PublishMessage{Topic: "nest/topic", Payload: []byte("payload"), Retain: true, QoS: 1}
+
+	command := PublishCommand(message)
+
+	assert.Equal(t, PublishCommandKind, command.Kind)
+	assert.Equal(t, message, command.Publish)
+}
+
+func TestActorEvents(t *testing.T) {
+	message := PublishMessage{Topic: "nest/topic", Payload: []byte("payload")}
+
+	assert.Equal(t, Event{Kind: ConnectedEventKind}, ConnectedEvent())
+	assert.Equal(t, Event{Kind: ConnectFailedKind, Error: "connect failed"}, ConnectFailedEvent(errors.New("connect failed")))
+	assert.Equal(t, Event{Kind: ConnectFailedKind}, ConnectFailedEvent(nil))
+	assert.Equal(t, Event{Kind: DisconnectedEventKind}, DisconnectedEvent())
+	assert.Equal(t, Event{Kind: PublishedEventKind, Publish: message}, PublishedEvent(message))
+	assert.Equal(t, Event{Kind: PublishFailedKind, Publish: message, Error: "publish failed"}, PublishFailedEvent(message, errors.New("publish failed")))
+	assert.Equal(t, Event{Kind: PublishFailedKind, Publish: message}, PublishFailedEvent(message, nil))
+}

--- a/internal/mqtt/discovery.go
+++ b/internal/mqtt/discovery.go
@@ -9,19 +9,13 @@ import (
 const DiscoverySchemaVersion = 1
 
 type DiscoveryDocument struct {
-	SchemaVersion int                    `json:"schema_version"`
-	UnitID        string                 `json:"unit_id"`
-	Availability  string                 `json:"availability_topic"`
-	RawSysfs      []RawSysfsDiscovery    `json:"raw_sysfs"`
+	SchemaVersion int                     `json:"schema_version"`
+	UnitID        string                  `json:"unit_id"`
+	Availability  string                  `json:"availability_topic"`
 	DigitalInputs []DigitalInputDiscovery `json:"digital_inputs"`
 	PushButtons   []PushButtonDiscovery   `json:"push_buttons"`
 	Relays        []RelayDiscovery        `json:"relays"`
 	Lights        []LightDiscovery        `json:"lights"`
-}
-
-type RawSysfsDiscovery struct {
-	DeviceID   string `json:"device_id"`
-	StateTopic string `json:"state_topic"`
 }
 
 type DigitalInputDiscovery struct {
@@ -45,12 +39,12 @@ type RelayDiscovery struct {
 }
 
 type LightDiscovery struct {
-	ID             string   `json:"id"`
-	Name           string   `json:"name"`
-	Relay          string   `json:"relay"`
-	Capabilities   []string `json:"capabilities"`
-	StateTopic     string   `json:"state_topic"`
-	CommandTopic   string   `json:"command_topic"`
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	Relay           string   `json:"relay"`
+	Capabilities    []string `json:"capabilities"`
+	StateTopic      string   `json:"state_topic"`
+	CommandTopic    string   `json:"command_topic"`
 	CommandsEnabled bool     `json:"commands_enabled"`
 }
 
@@ -59,7 +53,6 @@ func BuildDiscovery(root *entity.Root, topics Topics) DiscoveryDocument {
 		SchemaVersion: DiscoverySchemaVersion,
 		UnitID:        topics.UnitID,
 		Availability:  AvailabilityTopic(topics),
-		RawSysfs:      make([]RawSysfsDiscovery, 0, len(root.DigitalInputs)+len(root.Relays)),
 		DigitalInputs: make([]DigitalInputDiscovery, 0, len(root.DigitalInputs)),
 		PushButtons:   make([]PushButtonDiscovery, 0, len(root.PushButtons)),
 		Relays:        make([]RelayDiscovery, 0, len(root.Relays)),
@@ -67,10 +60,6 @@ func BuildDiscovery(root *entity.Root, topics Topics) DiscoveryDocument {
 	}
 
 	for _, input := range root.DigitalInputs {
-		doc.RawSysfs = append(doc.RawSysfs, RawSysfsDiscovery{
-			DeviceID:   string(input.SysfsDevice),
-			StateTopic: RawSysfsStateTopic(topics, input.SysfsDevice),
-		})
 		doc.DigitalInputs = append(doc.DigitalInputs, DigitalInputDiscovery{
 			ID:          string(input.ID),
 			SysfsDevice: string(input.SysfsDevice),
@@ -88,10 +77,6 @@ func BuildDiscovery(root *entity.Root, topics Topics) DiscoveryDocument {
 	}
 
 	for _, relay := range root.Relays {
-		doc.RawSysfs = append(doc.RawSysfs, RawSysfsDiscovery{
-			DeviceID:   string(relay.SysfsDevice),
-			StateTopic: RawSysfsStateTopic(topics, relay.SysfsDevice),
-		})
 		doc.Relays = append(doc.Relays, RelayDiscovery{
 			ID:          string(relay.ID),
 			Name:        relay.Name,
@@ -102,12 +87,12 @@ func BuildDiscovery(root *entity.Root, topics Topics) DiscoveryDocument {
 
 	for _, light := range root.Lights {
 		doc.Lights = append(doc.Lights, LightDiscovery{
-			ID:             string(light.ID),
-			Name:           light.Name,
-			Relay:          string(light.Relay),
-			Capabilities:   []string{"toggle"},
-			StateTopic:     LightStateTopic(topics, light.ID),
-			CommandTopic:   LightCommandTopic(topics, light.ID),
+			ID:              string(light.ID),
+			Name:            light.Name,
+			Relay:           string(light.Relay),
+			Capabilities:    []string{"toggle"},
+			StateTopic:      LightStateTopic(topics, light.ID),
+			CommandTopic:    LightCommandTopic(topics, light.ID),
 			CommandsEnabled: false,
 		})
 	}

--- a/internal/mqtt/discovery.go
+++ b/internal/mqtt/discovery.go
@@ -1,0 +1,125 @@
+package mqtt
+
+import (
+	"encoding/json"
+
+	"github.com/mhemeryck/nest/internal/entity"
+)
+
+const DiscoverySchemaVersion = 1
+
+type DiscoveryDocument struct {
+	SchemaVersion int                    `json:"schema_version"`
+	UnitID        string                 `json:"unit_id"`
+	Availability  string                 `json:"availability_topic"`
+	RawSysfs      []RawSysfsDiscovery    `json:"raw_sysfs"`
+	DigitalInputs []DigitalInputDiscovery `json:"digital_inputs"`
+	PushButtons   []PushButtonDiscovery   `json:"push_buttons"`
+	Relays        []RelayDiscovery        `json:"relays"`
+	Lights        []LightDiscovery        `json:"lights"`
+}
+
+type RawSysfsDiscovery struct {
+	DeviceID   string `json:"device_id"`
+	StateTopic string `json:"state_topic"`
+}
+
+type DigitalInputDiscovery struct {
+	ID          string `json:"id"`
+	SysfsDevice string `json:"sysfs_device"`
+	StateTopic  string `json:"state_topic"`
+}
+
+type PushButtonDiscovery struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Input      string `json:"input"`
+	StateTopic string `json:"state_topic"`
+}
+
+type RelayDiscovery struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	SysfsDevice string `json:"sysfs_device"`
+	StateTopic  string `json:"state_topic"`
+}
+
+type LightDiscovery struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Relay          string   `json:"relay"`
+	Capabilities   []string `json:"capabilities"`
+	StateTopic     string   `json:"state_topic"`
+	CommandTopic   string   `json:"command_topic"`
+	CommandsEnabled bool     `json:"commands_enabled"`
+}
+
+func BuildDiscovery(root *entity.Root, topics Topics) DiscoveryDocument {
+	doc := DiscoveryDocument{
+		SchemaVersion: DiscoverySchemaVersion,
+		UnitID:        topics.UnitID,
+		Availability:  AvailabilityTopic(topics),
+		RawSysfs:      make([]RawSysfsDiscovery, 0, len(root.DigitalInputs)+len(root.Relays)),
+		DigitalInputs: make([]DigitalInputDiscovery, 0, len(root.DigitalInputs)),
+		PushButtons:   make([]PushButtonDiscovery, 0, len(root.PushButtons)),
+		Relays:        make([]RelayDiscovery, 0, len(root.Relays)),
+		Lights:        make([]LightDiscovery, 0, len(root.Lights)),
+	}
+
+	for _, input := range root.DigitalInputs {
+		doc.RawSysfs = append(doc.RawSysfs, RawSysfsDiscovery{
+			DeviceID:   string(input.SysfsDevice),
+			StateTopic: RawSysfsStateTopic(topics, input.SysfsDevice),
+		})
+		doc.DigitalInputs = append(doc.DigitalInputs, DigitalInputDiscovery{
+			ID:          string(input.ID),
+			SysfsDevice: string(input.SysfsDevice),
+			StateTopic:  DigitalInputStateTopic(topics, input.ID),
+		})
+	}
+
+	for _, button := range root.PushButtons {
+		doc.PushButtons = append(doc.PushButtons, PushButtonDiscovery{
+			ID:         string(button.ID),
+			Name:       button.Name,
+			Input:      string(button.Input),
+			StateTopic: PushButtonStateTopic(topics, button.ID),
+		})
+	}
+
+	for _, relay := range root.Relays {
+		doc.RawSysfs = append(doc.RawSysfs, RawSysfsDiscovery{
+			DeviceID:   string(relay.SysfsDevice),
+			StateTopic: RawSysfsStateTopic(topics, relay.SysfsDevice),
+		})
+		doc.Relays = append(doc.Relays, RelayDiscovery{
+			ID:          string(relay.ID),
+			Name:        relay.Name,
+			SysfsDevice: string(relay.SysfsDevice),
+			StateTopic:  RelayStateTopic(topics, relay.ID),
+		})
+	}
+
+	for _, light := range root.Lights {
+		doc.Lights = append(doc.Lights, LightDiscovery{
+			ID:             string(light.ID),
+			Name:           light.Name,
+			Relay:          string(light.Relay),
+			Capabilities:   []string{"toggle"},
+			StateTopic:     LightStateTopic(topics, light.ID),
+			CommandTopic:   LightCommandTopic(topics, light.ID),
+			CommandsEnabled: false,
+		})
+	}
+
+	return doc
+}
+
+func DiscoveryPayload(root *entity.Root, topics Topics) ([]byte, error) {
+	payload, err := json.Marshal(BuildDiscovery(root, topics))
+	if err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}

--- a/internal/mqtt/discovery_test.go
+++ b/internal/mqtt/discovery_test.go
@@ -18,10 +18,6 @@ func TestBuildDiscovery(t *testing.T) {
 	assert.Equal(t, DiscoverySchemaVersion, doc.SchemaVersion)
 	assert.Equal(t, "controller_1", doc.UnitID)
 	assert.Equal(t, "nest/units/controller_1/availability", doc.Availability)
-	assert.Equal(t, []RawSysfsDiscovery{
-		{DeviceID: "di_3_16", StateTopic: "nest/units/controller_1/sysfs/di_3_16/state"},
-		{DeviceID: "ro_3_14", StateTopic: "nest/units/controller_1/sysfs/ro_3_14/state"},
-	}, doc.RawSysfs)
 	assert.Equal(t, []DigitalInputDiscovery{{
 		ID:          "office_button_input",
 		SysfsDevice: "di_3_16",

--- a/internal/mqtt/discovery_test.go
+++ b/internal/mqtt/discovery_test.go
@@ -1,0 +1,85 @@
+package mqtt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDiscovery(t *testing.T) {
+	root := testEntityRoot()
+	topics := NewTopics("nest", "controller_1")
+
+	doc := BuildDiscovery(root, topics)
+
+	assert.Equal(t, DiscoverySchemaVersion, doc.SchemaVersion)
+	assert.Equal(t, "controller_1", doc.UnitID)
+	assert.Equal(t, "nest/units/controller_1/availability", doc.Availability)
+	assert.Equal(t, []RawSysfsDiscovery{
+		{DeviceID: "di_3_16", StateTopic: "nest/units/controller_1/sysfs/di_3_16/state"},
+		{DeviceID: "ro_3_14", StateTopic: "nest/units/controller_1/sysfs/ro_3_14/state"},
+	}, doc.RawSysfs)
+	assert.Equal(t, []DigitalInputDiscovery{{
+		ID:          "office_button_input",
+		SysfsDevice: "di_3_16",
+		StateTopic:  "nest/units/controller_1/digital_inputs/office_button_input/state",
+	}}, doc.DigitalInputs)
+	assert.Equal(t, []PushButtonDiscovery{{
+		ID:         "office_button",
+		Name:       "Office button",
+		Input:      "office_button_input",
+		StateTopic: "nest/units/controller_1/push_buttons/office_button/state",
+	}}, doc.PushButtons)
+	assert.Equal(t, []RelayDiscovery{{
+		ID:          "office_light_relay",
+		Name:        "Office light relay",
+		SysfsDevice: "ro_3_14",
+		StateTopic:  "nest/units/controller_1/relays/office_light_relay/state",
+	}}, doc.Relays)
+	assert.Equal(t, []LightDiscovery{{
+		ID:              "office_light",
+		Name:            "Office light",
+		Relay:           "office_light_relay",
+		Capabilities:    []string{"toggle"},
+		StateTopic:      "nest/units/controller_1/lights/office_light/state",
+		CommandTopic:    "nest/units/controller_1/lights/office_light/command",
+		CommandsEnabled: false,
+	}}, doc.Lights)
+}
+
+func TestDiscoveryPayload(t *testing.T) {
+	payload, err := DiscoveryPayload(testEntityRoot(), NewTopics("nest", "controller_1"))
+	require.NoError(t, err)
+
+	var doc DiscoveryDocument
+	require.NoError(t, json.Unmarshal(payload, &doc))
+	assert.Equal(t, "controller_1", doc.UnitID)
+	assert.False(t, doc.Lights[0].CommandsEnabled)
+}
+
+func testEntityRoot() *entity.Root {
+	return &entity.Root{
+		DigitalInputs: []entity.DigitalInput{{
+			ID:          entity.DigitalInputID("office_button_input"),
+			SysfsDevice: entity.SysfsDeviceID("di_3_16"),
+		}},
+		PushButtons: []entity.PushButton{{
+			ID:    entity.PushButtonID("office_button"),
+			Name:  "Office button",
+			Input: entity.DigitalInputID("office_button_input"),
+		}},
+		Relays: []entity.Relay{{
+			ID:          entity.RelayID("office_light_relay"),
+			Name:        "Office light relay",
+			SysfsDevice: entity.SysfsDeviceID("ro_3_14"),
+		}},
+		Lights: []entity.Light{{
+			ID:    entity.LightID("office_light"),
+			Name:  "Office light",
+			Relay: entity.RelayID("office_light_relay"),
+		}},
+	}
+}

--- a/internal/mqtt/message.go
+++ b/internal/mqtt/message.go
@@ -39,6 +39,13 @@ type RelayObservation struct {
 	Value       int                  `json:"value"`
 }
 
+type LightObservation struct {
+	LightID entity.LightID `json:"light_id"`
+	Name    string         `json:"name"`
+	RelayID entity.RelayID `json:"relay_id"`
+	Value   int            `json:"value"`
+}
+
 func AvailabilityMessage(topics Topics, status AvailabilityStatus) PublishMessage {
 	return PublishMessage{
 		Topic:   AvailabilityTopic(topics),
@@ -98,6 +105,20 @@ func RelayStateMessage(topics Topics, observation RelayObservation) (PublishMess
 
 	return PublishMessage{
 		Topic:   RelayStateTopic(topics, observation.RelayID),
+		Payload: payload,
+		Retain:  true,
+		QoS:     0,
+	}, nil
+}
+
+func LightStateMessage(topics Topics, observation LightObservation) (PublishMessage, error) {
+	payload, err := json.Marshal(observation)
+	if err != nil {
+		return PublishMessage{}, err
+	}
+
+	return PublishMessage{
+		Topic:   LightStateTopic(topics, observation.LightID),
 		Payload: payload,
 		Retain:  true,
 		QoS:     0,

--- a/internal/mqtt/message.go
+++ b/internal/mqtt/message.go
@@ -1,0 +1,105 @@
+package mqtt
+
+import (
+	"encoding/json"
+
+	"github.com/mhemeryck/nest/internal/entity"
+)
+
+type PublishMessage struct {
+	Topic   string
+	Payload []byte
+	Retain  bool
+	QoS     byte
+}
+
+type AvailabilityStatus string
+
+const (
+	AvailabilityOnline  AvailabilityStatus = "online"
+	AvailabilityOffline AvailabilityStatus = "offline"
+)
+
+type DigitalInputObservation struct {
+	InputID     entity.DigitalInputID `json:"input_id"`
+	SysfsDevice entity.SysfsDeviceID  `json:"sysfs_device"`
+	Value       int                   `json:"value"`
+}
+
+type PushButtonObservation struct {
+	ButtonID entity.PushButtonID `json:"button_id"`
+	Name     string              `json:"name"`
+	State    string              `json:"state"`
+}
+
+type RelayObservation struct {
+	RelayID     entity.RelayID       `json:"relay_id"`
+	Name        string               `json:"name"`
+	SysfsDevice entity.SysfsDeviceID `json:"sysfs_device"`
+	Value       int                  `json:"value"`
+}
+
+func AvailabilityMessage(topics Topics, status AvailabilityStatus) PublishMessage {
+	return PublishMessage{
+		Topic:   AvailabilityTopic(topics),
+		Payload: []byte(status),
+		Retain:  true,
+		QoS:     0,
+	}
+}
+
+func DiscoveryMessage(root *entity.Root, topics Topics) (PublishMessage, error) {
+	payload, err := DiscoveryPayload(root, topics)
+	if err != nil {
+		return PublishMessage{}, err
+	}
+
+	return PublishMessage{
+		Topic:   DiscoveryTopic(topics),
+		Payload: payload,
+		Retain:  true,
+		QoS:     0,
+	}, nil
+}
+
+func DigitalInputStateMessage(topics Topics, observation DigitalInputObservation) (PublishMessage, error) {
+	payload, err := json.Marshal(observation)
+	if err != nil {
+		return PublishMessage{}, err
+	}
+
+	return PublishMessage{
+		Topic:   DigitalInputStateTopic(topics, observation.InputID),
+		Payload: payload,
+		Retain:  true,
+		QoS:     0,
+	}, nil
+}
+
+func PushButtonStateMessage(topics Topics, observation PushButtonObservation) (PublishMessage, error) {
+	payload, err := json.Marshal(observation)
+	if err != nil {
+		return PublishMessage{}, err
+	}
+
+	return PublishMessage{
+		Topic:   PushButtonStateTopic(topics, observation.ButtonID),
+		Payload: payload,
+		Retain:  false,
+		QoS:     0,
+	}, nil
+}
+
+func RelayStateMessage(topics Topics, observation RelayObservation) (PublishMessage, error) {
+	payload, err := json.Marshal(observation)
+	if err != nil {
+		return PublishMessage{}, err
+	}
+
+	return PublishMessage{
+		Topic:   RelayStateTopic(topics, observation.RelayID),
+		Payload: payload,
+		Retain:  true,
+		QoS:     0,
+	}, nil
+}

--- a/internal/mqtt/message_test.go
+++ b/internal/mqtt/message_test.go
@@ -69,3 +69,18 @@ func TestRelayStateMessage(t *testing.T) {
 	assert.True(t, message.Retain)
 	assert.Equal(t, byte(0), message.QoS)
 }
+
+func TestLightStateMessage(t *testing.T) {
+	message, err := LightStateMessage(NewTopics("nest", "controller_1"), LightObservation{
+		LightID: entity.LightID("office_light"),
+		Name:    "Office light",
+		RelayID: entity.RelayID("office_light_relay"),
+		Value:   1,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "nest/units/controller_1/lights/office_light/state", message.Topic)
+	assert.JSONEq(t, `{"light_id":"office_light","name":"Office light","relay_id":"office_light_relay","value":1}`, string(message.Payload))
+	assert.True(t, message.Retain)
+	assert.Equal(t, byte(0), message.QoS)
+}

--- a/internal/mqtt/message_test.go
+++ b/internal/mqtt/message_test.go
@@ -1,0 +1,71 @@
+package mqtt
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAvailabilityMessage(t *testing.T) {
+	message := AvailabilityMessage(NewTopics("nest", "controller_1"), AvailabilityOnline)
+
+	assert.Equal(t, "nest/units/controller_1/availability", message.Topic)
+	assert.Equal(t, []byte("online"), message.Payload)
+	assert.True(t, message.Retain)
+	assert.Equal(t, byte(0), message.QoS)
+}
+
+func TestDiscoveryMessage(t *testing.T) {
+	message, err := DiscoveryMessage(testEntityRoot(), NewTopics("nest", "controller_1"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "nest/units/controller_1/discovery", message.Topic)
+	assert.Contains(t, string(message.Payload), `"commands_enabled":false`)
+	assert.True(t, message.Retain)
+	assert.Equal(t, byte(0), message.QoS)
+}
+
+func TestDigitalInputStateMessage(t *testing.T) {
+	message, err := DigitalInputStateMessage(NewTopics("nest", "controller_1"), DigitalInputObservation{
+		InputID:     entity.DigitalInputID("office_button_input"),
+		SysfsDevice: entity.SysfsDeviceID("di_3_16"),
+		Value:       1,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "nest/units/controller_1/digital_inputs/office_button_input/state", message.Topic)
+	assert.JSONEq(t, `{"input_id":"office_button_input","sysfs_device":"di_3_16","value":1}`, string(message.Payload))
+	assert.True(t, message.Retain)
+	assert.Equal(t, byte(0), message.QoS)
+}
+
+func TestPushButtonStateMessage(t *testing.T) {
+	message, err := PushButtonStateMessage(NewTopics("nest", "controller_1"), PushButtonObservation{
+		ButtonID: entity.PushButtonID("office_button"),
+		Name:     "Office button",
+		State:    "pressed",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "nest/units/controller_1/push_buttons/office_button/state", message.Topic)
+	assert.JSONEq(t, `{"button_id":"office_button","name":"Office button","state":"pressed"}`, string(message.Payload))
+	assert.False(t, message.Retain)
+	assert.Equal(t, byte(0), message.QoS)
+}
+
+func TestRelayStateMessage(t *testing.T) {
+	message, err := RelayStateMessage(NewTopics("nest", "controller_1"), RelayObservation{
+		RelayID:     entity.RelayID("office_light_relay"),
+		Name:        "Office light relay",
+		SysfsDevice: entity.SysfsDeviceID("ro_3_14"),
+		Value:       1,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "nest/units/controller_1/relays/office_light_relay/state", message.Topic)
+	assert.JSONEq(t, `{"relay_id":"office_light_relay","name":"Office light relay","sysfs_device":"ro_3_14","value":1}`, string(message.Payload))
+	assert.True(t, message.Retain)
+	assert.Equal(t, byte(0), message.QoS)
+}

--- a/internal/mqtt/run.go
+++ b/internal/mqtt/run.go
@@ -1,0 +1,108 @@
+package mqtt
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+	"github.com/mhemeryck/nest/internal/entity"
+)
+
+const disconnectQuiesce = 250 * time.Millisecond
+
+func Run(ctx context.Context, cfg entity.MQTT, commands <-chan Command, events chan<- Event, done chan<- struct{}) {
+	defer close(done)
+
+	client := paho.NewClient(clientOptions(cfg))
+	if err := waitToken(ctx, client.Connect()); err != nil {
+		slog.Error("mqtt connect failed", "broker", brokerURL(cfg), "error", err)
+		publishEvent(ctx, events, ConnectFailedEvent(err))
+		return
+	}
+
+	slog.Info("mqtt connected", "broker", brokerURL(cfg), "client_id", cfg.ClientID)
+	publishEvent(ctx, events, ConnectedEvent())
+	defer func() {
+		client.Disconnect(uint(disconnectQuiesce / time.Millisecond))
+		publishEvent(ctx, events, DisconnectedEvent())
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case command, ok := <-commands:
+			if !ok {
+				return
+			}
+			handleCommand(ctx, client, events, command)
+		}
+	}
+}
+
+func handleCommand(ctx context.Context, client paho.Client, events chan<- Event, command Command) {
+	switch command.Kind {
+	case PublishCommandKind:
+		publish(ctx, client, events, command.Publish)
+	default:
+		return
+	}
+}
+
+func publish(ctx context.Context, client paho.Client, events chan<- Event, message PublishMessage) {
+	token := client.Publish(message.Topic, message.QoS, message.Retain, message.Payload)
+	if err := waitToken(ctx, token); err != nil {
+		slog.Error("mqtt publish failed", "topic", message.Topic, "error", err)
+		publishEvent(ctx, events, PublishFailedEvent(message, err))
+		return
+	}
+
+	publishEvent(ctx, events, PublishedEvent(message))
+}
+
+func clientOptions(cfg entity.MQTT) *paho.ClientOptions {
+	options := paho.NewClientOptions()
+	options.AddBroker(brokerURL(cfg))
+	options.SetClientID(cfg.ClientID)
+	if cfg.Username != "" {
+		options.SetUsername(cfg.Username)
+	}
+	if cfg.Password != "" {
+		options.SetPassword(cfg.Password)
+	}
+	options.SetAutoReconnect(true)
+	options.SetConnectRetry(true)
+	options.SetOrderMatters(true)
+
+	return options
+}
+
+func brokerURL(cfg entity.MQTT) string {
+	return fmt.Sprintf("tcp://%s:%d", cfg.Host, cfg.Port)
+}
+
+func waitToken(ctx context.Context, token paho.Token) error {
+	done := make(chan struct{})
+	go func() {
+		token.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return token.Error()
+	}
+}
+
+func publishEvent(ctx context.Context, events chan<- Event, event Event) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case events <- event:
+		return true
+	}
+}

--- a/internal/mqtt/run_test.go
+++ b/internal/mqtt/run_test.go
@@ -1,0 +1,31 @@
+package mqtt
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBrokerURL(t *testing.T) {
+	url := brokerURL(entity.MQTT{Host: "mqtt.local", Port: 1883})
+
+	assert.Equal(t, "tcp://mqtt.local:1883", url)
+}
+
+func TestClientOptions(t *testing.T) {
+	options := clientOptions(entity.MQTT{
+		Host:     "mqtt.local",
+		Port:     1883,
+		ClientID: "nest-controller-1",
+		Username: "nest",
+		Password: "secret",
+	})
+
+	assert.Equal(t, "nest-controller-1", options.ClientID)
+	assert.Equal(t, "nest", options.Username)
+	assert.Equal(t, "secret", options.Password)
+	if assert.Len(t, options.Servers, 1) {
+		assert.Equal(t, "tcp://mqtt.local:1883", options.Servers[0].String())
+	}
+}

--- a/internal/mqtt/startup.go
+++ b/internal/mqtt/startup.go
@@ -1,0 +1,16 @@
+package mqtt
+
+import "github.com/mhemeryck/nest/internal/entity"
+
+func StartupCommands(root *entity.Root) ([]Command, error) {
+	topics := NewTopics(root.MQTT.TopicPrefix, root.MQTT.UnitID)
+	discovery, err := DiscoveryMessage(root, topics)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Command{
+		PublishCommand(discovery),
+		PublishCommand(AvailabilityMessage(topics, AvailabilityOnline)),
+	}, nil
+}

--- a/internal/mqtt/startup_test.go
+++ b/internal/mqtt/startup_test.go
@@ -1,0 +1,41 @@
+package mqtt
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartupCommands(t *testing.T) {
+	root := &entity.Root{
+		MQTT: entity.MQTT{
+			TopicPrefix: "nest",
+			UnitID:      "controller_1",
+		},
+		Relays: []entity.Relay{{
+			ID:          entity.RelayID("office_light_relay"),
+			Name:        "Office light relay",
+			SysfsDevice: entity.SysfsDeviceID("ro_3_14"),
+		}},
+		Lights: []entity.Light{{
+			ID:    entity.LightID("office_light"),
+			Name:  "Office light",
+			Relay: entity.RelayID("office_light_relay"),
+		}},
+	}
+
+	commands, err := StartupCommands(root)
+	require.NoError(t, err)
+	require.Len(t, commands, 2)
+
+	assert.Equal(t, PublishCommandKind, commands[0].Kind)
+	assert.Equal(t, "nest/units/controller_1/discovery", commands[0].Publish.Topic)
+	assert.True(t, commands[0].Publish.Retain)
+	assert.Contains(t, string(commands[0].Publish.Payload), `"commands_enabled":false`)
+	assert.Equal(t, PublishCommandKind, commands[1].Kind)
+	assert.Equal(t, "nest/units/controller_1/availability", commands[1].Publish.Topic)
+	assert.Equal(t, []byte("online"), commands[1].Publish.Payload)
+	assert.True(t, commands[1].Publish.Retain)
+}

--- a/internal/mqtt/topics.go
+++ b/internal/mqtt/topics.go
@@ -1,0 +1,61 @@
+package mqtt
+
+import (
+	"strings"
+
+	"github.com/mhemeryck/nest/internal/entity"
+)
+
+type Topics struct {
+	Prefix string
+	UnitID string
+}
+
+func NewTopics(prefix string, unitID string) Topics {
+	return Topics{
+		Prefix: strings.Trim(prefix, "/"),
+		UnitID: unitID,
+	}
+}
+
+func AvailabilityTopic(topics Topics) string {
+	return joinTopic(topics, "units", topics.UnitID, "availability")
+}
+
+func DiscoveryTopic(topics Topics) string {
+	return joinTopic(topics, "units", topics.UnitID, "discovery")
+}
+
+func RawSysfsStateTopic(topics Topics, deviceID entity.SysfsDeviceID) string {
+	return joinTopic(topics, "units", topics.UnitID, "sysfs", string(deviceID), "state")
+}
+
+func DigitalInputStateTopic(topics Topics, inputID entity.DigitalInputID) string {
+	return joinTopic(topics, "units", topics.UnitID, "digital_inputs", string(inputID), "state")
+}
+
+func PushButtonStateTopic(topics Topics, buttonID entity.PushButtonID) string {
+	return joinTopic(topics, "units", topics.UnitID, "push_buttons", string(buttonID), "state")
+}
+
+func RelayStateTopic(topics Topics, relayID entity.RelayID) string {
+	return joinTopic(topics, "units", topics.UnitID, "relays", string(relayID), "state")
+}
+
+func LightStateTopic(topics Topics, lightID entity.LightID) string {
+	return joinTopic(topics, "units", topics.UnitID, "lights", string(lightID), "state")
+}
+
+func LightCommandTopic(topics Topics, lightID entity.LightID) string {
+	return joinTopic(topics, "units", topics.UnitID, "lights", string(lightID), "command")
+}
+
+func joinTopic(topics Topics, parts ...string) string {
+	segments := make([]string, 0, len(parts)+1)
+	if topics.Prefix != "" {
+		segments = append(segments, topics.Prefix)
+	}
+	segments = append(segments, parts...)
+
+	return strings.Join(segments, "/")
+}

--- a/internal/mqtt/topics.go
+++ b/internal/mqtt/topics.go
@@ -26,10 +26,6 @@ func DiscoveryTopic(topics Topics) string {
 	return joinTopic(topics, "units", topics.UnitID, "discovery")
 }
 
-func RawSysfsStateTopic(topics Topics, deviceID entity.SysfsDeviceID) string {
-	return joinTopic(topics, "units", topics.UnitID, "sysfs", string(deviceID), "state")
-}
-
 func DigitalInputStateTopic(topics Topics, inputID entity.DigitalInputID) string {
 	return joinTopic(topics, "units", topics.UnitID, "digital_inputs", string(inputID), "state")
 }

--- a/internal/mqtt/topics_test.go
+++ b/internal/mqtt/topics_test.go
@@ -1,0 +1,29 @@
+package mqtt
+
+import (
+	"testing"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTopics(t *testing.T) {
+	topics := NewTopics("/nest/", "controller_1")
+
+	assert.Equal(t, "nest", topics.Prefix)
+	assert.Equal(t, "controller_1", topics.UnitID)
+	assert.Equal(t, "nest/units/controller_1/availability", AvailabilityTopic(topics))
+	assert.Equal(t, "nest/units/controller_1/discovery", DiscoveryTopic(topics))
+	assert.Equal(t, "nest/units/controller_1/sysfs/di_3_16/state", RawSysfsStateTopic(topics, entity.SysfsDeviceID("di_3_16")))
+	assert.Equal(t, "nest/units/controller_1/digital_inputs/office_button_input/state", DigitalInputStateTopic(topics, entity.DigitalInputID("office_button_input")))
+	assert.Equal(t, "nest/units/controller_1/push_buttons/office_button/state", PushButtonStateTopic(topics, entity.PushButtonID("office_button")))
+	assert.Equal(t, "nest/units/controller_1/relays/office_light_relay/state", RelayStateTopic(topics, entity.RelayID("office_light_relay")))
+	assert.Equal(t, "nest/units/controller_1/lights/office_light/state", LightStateTopic(topics, entity.LightID("office_light")))
+	assert.Equal(t, "nest/units/controller_1/lights/office_light/command", LightCommandTopic(topics, entity.LightID("office_light")))
+}
+
+func TestTopicsWithoutPrefix(t *testing.T) {
+	topics := NewTopics("", "controller_1")
+
+	assert.Equal(t, "units/controller_1/availability", AvailabilityTopic(topics))
+}

--- a/internal/mqtt/topics_test.go
+++ b/internal/mqtt/topics_test.go
@@ -14,7 +14,6 @@ func TestTopics(t *testing.T) {
 	assert.Equal(t, "controller_1", topics.UnitID)
 	assert.Equal(t, "nest/units/controller_1/availability", AvailabilityTopic(topics))
 	assert.Equal(t, "nest/units/controller_1/discovery", DiscoveryTopic(topics))
-	assert.Equal(t, "nest/units/controller_1/sysfs/di_3_16/state", RawSysfsStateTopic(topics, entity.SysfsDeviceID("di_3_16")))
 	assert.Equal(t, "nest/units/controller_1/digital_inputs/office_button_input/state", DigitalInputStateTopic(topics, entity.DigitalInputID("office_button_input")))
 	assert.Equal(t, "nest/units/controller_1/push_buttons/office_button/state", PushButtonStateTopic(topics, entity.PushButtonID("office_button")))
 	assert.Equal(t, "nest/units/controller_1/relays/office_light_relay/state", RelayStateTopic(topics, entity.RelayID("office_light_relay")))

--- a/internal/nest/mqtt.go
+++ b/internal/nest/mqtt.go
@@ -1,0 +1,68 @@
+package nest
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/mqtt"
+)
+
+func mqttChannels(root *entity.Root) (chan mqtt.Command, chan mqtt.Event, chan struct{}) {
+	if !root.MQTT.Enabled {
+		return nil, nil, nil
+	}
+
+	commands := make(chan mqtt.Command, 32)
+	events := make(chan mqtt.Event, 32)
+	done := make(chan struct{})
+
+	return commands, events, done
+}
+
+func publishMQTTStartup(ctx context.Context, root *entity.Root, commands chan<- mqtt.Command) error {
+	startupCommands, err := mqtt.StartupCommands(root)
+	if err != nil {
+		return fmt.Errorf("build mqtt startup commands: %w", err)
+	}
+
+	for _, command := range startupCommands {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case commands <- command:
+		}
+	}
+
+	return nil
+}
+
+func logMQTTEvents(ctx context.Context, events <-chan mqtt.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-events:
+			if !ok {
+				return
+			}
+			logMQTTEvent(event)
+		}
+	}
+}
+
+func logMQTTEvent(event mqtt.Event) {
+	switch event.Kind {
+	case mqtt.ConnectedEventKind:
+		slog.Info("mqtt actor connected")
+	case mqtt.ConnectFailedKind:
+		slog.Error("mqtt actor connect failed", "error", event.Error)
+	case mqtt.DisconnectedEventKind:
+		slog.Info("mqtt actor disconnected")
+	case mqtt.PublishedEventKind:
+		slog.Debug("mqtt message published", "topic", event.Publish.Topic)
+	case mqtt.PublishFailedKind:
+		slog.Error("mqtt message publish failed", "topic", event.Publish.Topic, "error", event.Error)
+	}
+}

--- a/internal/nest/mqtt.go
+++ b/internal/nest/mqtt.go
@@ -21,6 +21,14 @@ func mqttChannels(root *entity.Root) (chan mqtt.Command, chan mqtt.Event, chan s
 	return commands, events, done
 }
 
+func mqttTopics(root *entity.Root) mqtt.Topics {
+	if !root.MQTT.Enabled {
+		return mqtt.Topics{}
+	}
+
+	return mqtt.NewTopics(root.MQTT.TopicPrefix, root.MQTT.UnitID)
+}
+
 func publishMQTTStartup(ctx context.Context, root *entity.Root, commands chan<- mqtt.Command) error {
 	startupCommands, err := mqtt.StartupCommands(root)
 	if err != nil {

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -77,7 +77,7 @@ func Run(ctx context.Context, opts Options) error {
 	go sysfs.Run(ctx, configuredDevices, sysfsCommands, states, sysfsDone)
 
 	controllerDone := make(chan struct{})
-	go controller.Run(ctx, index, sysfsCommands, states, controllerDone)
+	go controller.Run(ctx, index, sysfsCommands, mqttCommands, mqttTopics(root), states, controllerDone)
 
 	slog.Info("polling devices", "message", "press Ctrl+C to exit")
 

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -23,6 +23,7 @@ func Run(ctx context.Context, opts Options) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// Load and validate external configuration before building runtime state.
 	configRoot, err := config.Load(opts.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -33,9 +34,11 @@ func Run(ctx context.Context, opts Options) error {
 		return nil
 	}
 
+	// Translate config into domain entities and indexes used by controllers.
 	root := entity.FromConfig(configRoot)
 	index := registry.Build(root)
 
+	// Resolve configured sysfs devices against the hardware tree before actors start.
 	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
 	devices, err := sysfs.ListDevices(root.SysfsRoot)
 	if err != nil {
@@ -57,6 +60,7 @@ func Run(ctx context.Context, opts Options) error {
 		slog.Info("configured device", "identifier", device.Identifier, "path", device.Path)
 	}
 
+	// Start optional transport actors before local control so startup state is published early.
 	mqttCommands, mqttEvents, mqttDone := mqttChannels(root)
 	if mqttCommands != nil {
 		go mqtt.Run(ctx, root.MQTT, mqttCommands, mqttEvents, mqttDone)
@@ -68,6 +72,7 @@ func Run(ctx context.Context, opts Options) error {
 		}
 	}
 
+	// Start hardware and controller actors with unidirectional command and observation channels.
 	sysfsCommands, states, sysfsDone := sysfsChannels()
 	go sysfs.Run(ctx, configuredDevices, sysfsCommands, states, sysfsDone)
 
@@ -76,6 +81,7 @@ func Run(ctx context.Context, opts Options) error {
 
 	slog.Info("polling devices", "message", "press Ctrl+C to exit")
 
+	// Controller shutdown drives process shutdown and then actors are drained in order.
 	<-controllerDone
 	cancel()
 	<-sysfsDone

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mhemeryck/nest/internal/config"
 	"github.com/mhemeryck/nest/internal/controller"
 	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/mqtt"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
@@ -56,13 +57,22 @@ func Run(ctx context.Context, opts Options) error {
 		slog.Info("configured device", "identifier", device.Identifier, "path", device.Path)
 	}
 
-	commands := make(chan sysfs.Command, 32)
-	states := make(chan sysfs.StateChange, 32)
-	sysfsDone := make(chan struct{})
-	go sysfs.Run(ctx, configuredDevices, commands, states, sysfsDone)
+	mqttCommands, mqttEvents, mqttDone := mqttChannels(root)
+	if mqttCommands != nil {
+		go mqtt.Run(ctx, root.MQTT, mqttCommands, mqttEvents, mqttDone)
+		go logMQTTEvents(ctx, mqttEvents)
+		if err := publishMQTTStartup(ctx, root, mqttCommands); err != nil {
+			cancel()
+			<-mqttDone
+			return err
+		}
+	}
+
+	sysfsCommands, states, sysfsDone := sysfsChannels()
+	go sysfs.Run(ctx, configuredDevices, sysfsCommands, states, sysfsDone)
 
 	controllerDone := make(chan struct{})
-	go controller.Run(ctx, index, commands, states, controllerDone)
+	go controller.Run(ctx, index, sysfsCommands, states, controllerDone)
 
 	slog.Info("polling devices", "message", "press Ctrl+C to exit")
 
@@ -70,6 +80,12 @@ func Run(ctx context.Context, opts Options) error {
 	cancel()
 	<-sysfsDone
 	close(states)
+	if mqttDone != nil {
+		<-mqttDone
+	}
+	if mqttEvents != nil {
+		close(mqttEvents)
+	}
 
 	slog.Info("shutting down")
 	return nil

--- a/internal/nest/sysfs.go
+++ b/internal/nest/sysfs.go
@@ -1,0 +1,11 @@
+package nest
+
+import "github.com/mhemeryck/nest/internal/sysfs"
+
+func sysfsChannels() (chan sysfs.Command, chan sysfs.StateChange, chan struct{}) {
+	commands := make(chan sysfs.Command, 32)
+	states := make(chan sysfs.StateChange, 32)
+	done := make(chan struct{})
+
+	return commands, states, done
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -11,6 +11,7 @@ type Index struct {
 	PushButtonsByID       map[entity.PushButtonID]entity.PushButton
 	PushButtonsByInputID  map[entity.DigitalInputID][]entity.PushButton
 	LightsByID            map[entity.LightID]entity.Light
+	LightsByRelayID       map[entity.RelayID][]entity.Light
 	BindingsByButtonID    map[entity.PushButtonID][]entity.Binding
 	RelaysByID            map[entity.RelayID]entity.Relay
 	RelaysByDevice        map[entity.SysfsDeviceID]entity.Relay
@@ -22,6 +23,7 @@ func Build(root *entity.Root) *Index {
 		PushButtonsByID:       make(map[entity.PushButtonID]entity.PushButton, len(root.PushButtons)),
 		PushButtonsByInputID:  make(map[entity.DigitalInputID][]entity.PushButton),
 		LightsByID:            make(map[entity.LightID]entity.Light, len(root.Lights)),
+		LightsByRelayID:       make(map[entity.RelayID][]entity.Light),
 		BindingsByButtonID:    make(map[entity.PushButtonID][]entity.Binding),
 		RelaysByID:            make(map[entity.RelayID]entity.Relay, len(root.Relays)),
 		RelaysByDevice:        make(map[entity.SysfsDeviceID]entity.Relay, len(root.Relays)),
@@ -38,6 +40,7 @@ func Build(root *entity.Root) *Index {
 
 	for _, light := range root.Lights {
 		index.LightsByID[light.ID] = light
+		index.LightsByRelayID[light.Relay] = append(index.LightsByRelayID[light.Relay], light)
 	}
 
 	for _, relay := range root.Relays {
@@ -82,6 +85,10 @@ func BindingsByButton(index *Index, buttonID entity.PushButtonID) []entity.Bindi
 func LightByID(index *Index, lightID entity.LightID) (entity.Light, bool) {
 	light, ok := index.LightsByID[lightID]
 	return light, ok
+}
+
+func LightsByRelay(index *Index, relayID entity.RelayID) []entity.Light {
+	return index.LightsByRelayID[relayID]
 }
 
 func RelayByID(index *Index, relayID entity.RelayID) (entity.Relay, bool) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -88,3 +88,8 @@ func RelayByID(index *Index, relayID entity.RelayID) (entity.Relay, bool) {
 	relay, ok := index.RelaysByID[relayID]
 	return relay, ok
 }
+
+func RelayBySysfsDevice(index *Index, deviceID entity.SysfsDeviceID) (entity.Relay, bool) {
+	relay, ok := index.RelaysByDevice[deviceID]
+	return relay, ok
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -34,6 +34,7 @@ func TestBuild(t *testing.T) {
 	assert.Equal(t, root.PushButtons[0], index.PushButtonsByID[entity.PushButtonID("office_button")])
 	assert.Equal(t, root.PushButtons, index.PushButtonsByInputID[entity.DigitalInputID("office_button_input")])
 	assert.Equal(t, root.Lights[0], index.LightsByID[entity.LightID("office_light")])
+	assert.Equal(t, root.Lights, index.LightsByRelayID[entity.RelayID("office_light_relay")])
 	assert.Equal(t, root.Bindings, index.BindingsByButtonID[entity.PushButtonID("office_button")])
 	assert.Equal(t, root.Relays[0], index.RelaysByID[entity.RelayID("office_light_relay")])
 	assert.Equal(t, root.Relays[0], index.RelaysByDevice[entity.SysfsDeviceID("ro_3_14")])
@@ -70,6 +71,7 @@ func TestLookupHelpers(t *testing.T) {
 	light, ok := LightByID(index, entity.LightID("office_light"))
 	require.True(t, ok)
 	assert.Equal(t, root.Lights[0], light)
+	assert.Equal(t, root.Lights, LightsByRelay(index, entity.RelayID("office_light_relay")))
 
 	relay, ok := RelayByID(index, entity.RelayID("office_light_relay"))
 	require.True(t, ok)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -74,4 +74,8 @@ func TestLookupHelpers(t *testing.T) {
 	relay, ok := RelayByID(index, entity.RelayID("office_light_relay"))
 	require.True(t, ok)
 	assert.Equal(t, root.Relays[0], relay)
+
+	relay, ok = RelayBySysfsDevice(index, entity.SysfsDeviceID("ro_3_14"))
+	require.True(t, ok)
+	assert.Equal(t, root.Relays[0], relay)
 }

--- a/test/fixtures/config.local-mqtt.yaml
+++ b/test/fixtures/config.local-mqtt.yaml
@@ -1,0 +1,34 @@
+sysfs:
+  root: test/fixtures
+
+mqtt:
+  enabled: true
+  host: localhost
+  port: 1883
+  client_id: nest-local
+  topic_prefix: nest
+  unit_id: local
+
+digital_inputs:
+  - id: office_button_input
+    device: di_3_16
+
+push_buttons:
+  - id: office_button
+    name: Office light button
+    input: office_button_input
+
+relays:
+  - id: office_light_relay
+    name: Office light relay
+    device: ro_3_14
+
+lights:
+  - id: office_light
+    name: Office light
+    relay: office_light_relay
+
+bindings:
+  - button: office_button
+    light: office_light
+    action: toggle


### PR DESCRIPTION
Add passive MQTT observability for the next migration phase.

Introduce optional MQTT configuration, an MQTT actor with one-way
command and event channels, retained unit discovery, and startup
availability publishing. Controller-owned semantic events now publish
mapped input, push button, relay, and derived light state without
subscribing to commands or allowing MQTT to affect relay outputs.

This keeps MQTT as a passive actor while preserving local control when
MQTT is unavailable or slow.