### PR TITLE
Add configurable sysfs poll intervals

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -29,7 +30,14 @@ type Root struct {
 }
 
 type SysfsConfig struct {
-	Root string `yaml:"root"`
+	Root          string              `yaml:"root"`
+	PollIntervals PollIntervalsConfig `yaml:"poll_intervals"`
+}
+
+type PollIntervalsConfig struct {
+	DigitalInput  time.Duration `yaml:"digital_input"`
+	DigitalOutput time.Duration `yaml:"digital_output"`
+	RelayOutput   time.Duration `yaml:"relay_output"`
 }
 
 type MQTTConfig struct {
@@ -143,7 +151,20 @@ func Validate(f *Root) error {
 }
 
 func validateSysfs(sysfs SysfsConfig) error {
-	return validateRequiredField("sysfs.root", sysfs.Root)
+	return errors.Join(
+		validateRequiredField("sysfs.root", sysfs.Root),
+		validatePollInterval("sysfs.poll_intervals.digital_input", sysfs.PollIntervals.DigitalInput),
+		validatePollInterval("sysfs.poll_intervals.digital_output", sysfs.PollIntervals.DigitalOutput),
+		validatePollInterval("sysfs.poll_intervals.relay_output", sysfs.PollIntervals.RelayOutput),
+	)
+}
+
+func validatePollInterval(field string, value time.Duration) error {
+	if value < 0 {
+		return fmt.Errorf("%s: must not be negative", field)
+	}
+
+	return nil
 }
 
 func validateMQTT(mqtt MQTTConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,9 @@ func TestLoad(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "test/fixtures", file.Sysfs.Root)
+	assert.Equal(t, 100*time.Millisecond, file.Sysfs.PollIntervals.DigitalInput)
+	assert.Equal(t, 250*time.Millisecond, file.Sysfs.PollIntervals.DigitalOutput)
+	assert.Equal(t, time.Second, file.Sysfs.PollIntervals.RelayOutput)
 	assert.Len(t, file.DigitalInputs, 1)
 	assert.Len(t, file.PushButtons, 1)
 	assert.Len(t, file.Lights, 1)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,19 @@ func TestLoad(t *testing.T) {
 	assert.Len(t, file.Relays, 1)
 	assert.Len(t, file.Bindings, 1)
 	assert.Equal(t, []string{"di_3_16", "ro_3_14"}, DeviceIDs(file))
+}
+
+func TestLoadAcceptsSysfsPollIntervals(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.yaml")
+	writeTestFile(t, path, "sysfs:\n  root: /tmp\n  poll_intervals:\n    digital_input: 100ms\n    digital_output: 250ms\n    relay_output: 2s\ndigital_inputs:\n  - id: button_input\n    device: di_3_16\n")
+
+	file, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100*time.Millisecond, file.Sysfs.PollIntervals.DigitalInput)
+	assert.Equal(t, 250*time.Millisecond, file.Sysfs.PollIntervals.DigitalOutput)
+	assert.Equal(t, 2*time.Second, file.Sysfs.PollIntervals.RelayOutput)
 }
 
 func TestLoadRejectsUnknownFields(t *testing.T) {
@@ -69,6 +83,19 @@ func TestValidate(t *testing.T) {
 				Relays: []RelayConfig{{ID: "relay", Name: "Relay", Device: "ro_3_14"}},
 			},
 			message: "sysfs.root: must not have leading or trailing whitespace",
+		},
+		{
+			name: "rejects negative sysfs poll intervals",
+			file: Root{
+				Sysfs: SysfsConfig{
+					Root: "/tmp",
+					PollIntervals: PollIntervalsConfig{
+						DigitalInput: -time.Second,
+					},
+				},
+				DigitalInputs: []DigitalInputConfig{{ID: "button_input", Device: "di_3_16"}},
+			},
+			message: "sysfs.poll_intervals.digital_input: must not be negative",
 		},
 		{
 			name: "requires enabled MQTT host",

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -1,6 +1,10 @@
 package entity
 
-import "github.com/mhemeryck/nest/internal/config"
+import (
+	"time"
+
+	"github.com/mhemeryck/nest/internal/config"
+)
 
 type (
 	SysfsDeviceID  string
@@ -14,13 +18,20 @@ type (
 const LightActionToggle LightAction = "toggle"
 
 type Root struct {
-	SysfsRoot     string
-	MQTT          MQTT
-	DigitalInputs []DigitalInput
-	PushButtons   []PushButton
-	Lights        []Light
-	Relays        []Relay
-	Bindings      []Binding
+	SysfsRoot          string
+	SysfsPollIntervals PollIntervals
+	MQTT               MQTT
+	DigitalInputs      []DigitalInput
+	PushButtons        []PushButton
+	Lights             []Light
+	Relays             []Relay
+	Bindings           []Binding
+}
+
+type PollIntervals struct {
+	DigitalInput  time.Duration
+	DigitalOutput time.Duration
+	RelayOutput   time.Duration
 }
 
 type MQTT struct {
@@ -69,13 +80,14 @@ func FromConfig(root *config.Root) *Root {
 	}
 
 	entities := &Root{
-		SysfsRoot:     root.Sysfs.Root,
-		MQTT:          mqttFromConfig(root.MQTT),
-		DigitalInputs: make([]DigitalInput, 0, len(root.DigitalInputs)),
-		PushButtons:   make([]PushButton, 0, len(root.PushButtons)),
-		Lights:        make([]Light, 0, len(root.Lights)),
-		Relays:        make([]Relay, 0, len(root.Relays)),
-		Bindings:      make([]Binding, 0, len(root.Bindings)),
+		SysfsRoot:          root.Sysfs.Root,
+		SysfsPollIntervals: pollIntervalsFromConfig(root.Sysfs.PollIntervals),
+		MQTT:               mqttFromConfig(root.MQTT),
+		DigitalInputs:      make([]DigitalInput, 0, len(root.DigitalInputs)),
+		PushButtons:        make([]PushButton, 0, len(root.PushButtons)),
+		Lights:             make([]Light, 0, len(root.Lights)),
+		Relays:             make([]Relay, 0, len(root.Relays)),
+		Bindings:           make([]Binding, 0, len(root.Bindings)),
 	}
 
 	for _, input := range root.DigitalInputs {
@@ -118,6 +130,14 @@ func FromConfig(root *config.Root) *Root {
 	}
 
 	return entities
+}
+
+func pollIntervalsFromConfig(intervals config.PollIntervalsConfig) PollIntervals {
+	return PollIntervals{
+		DigitalInput:  intervals.DigitalInput,
+		DigitalOutput: intervals.DigitalOutput,
+		RelayOutput:   intervals.RelayOutput,
+	}
 }
 
 func mqttFromConfig(mqtt config.MQTTConfig) MQTT {

--- a/internal/entity/entity_test.go
+++ b/internal/entity/entity_test.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mhemeryck/nest/internal/config"
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,13 @@ import (
 
 func TestFromConfig(t *testing.T) {
 	root := FromConfig(&config.Root{
-		Sysfs: config.SysfsConfig{Root: "test/fixtures"},
+		Sysfs: config.SysfsConfig{
+			Root: "test/fixtures",
+			PollIntervals: config.PollIntervalsConfig{
+				DigitalInput: 100 * time.Millisecond,
+				RelayOutput:  2 * time.Second,
+			},
+		},
 		MQTT: config.MQTTConfig{
 			Enabled:     true,
 			Host:        "localhost",
@@ -49,6 +56,7 @@ func TestFromConfig(t *testing.T) {
 
 	require.NotNil(t, root)
 	assert.Equal(t, "test/fixtures", root.SysfsRoot)
+	assert.Equal(t, PollIntervals{DigitalInput: 100 * time.Millisecond, RelayOutput: 2 * time.Second}, root.SysfsPollIntervals)
 	assert.Equal(t, MQTT{
 		Enabled:     true,
 		Host:        "localhost",

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -74,7 +74,7 @@ func Run(ctx context.Context, opts Options) error {
 
 	// Start hardware and controller actors with unidirectional command and observation channels.
 	sysfsCommands, states, sysfsDone := sysfsChannels()
-	go sysfs.Run(ctx, configuredDevices, sysfsCommands, states, sysfsDone)
+	go sysfs.Run(ctx, configuredDevices, sysfsCommands, states, sysfsDone, sysfsPollIntervals(root))
 
 	controllerDone := make(chan struct{})
 	go controller.Run(ctx, index, sysfsCommands, mqttCommands, mqttTopics(root), states, controllerDone)

--- a/internal/nest/sysfs.go
+++ b/internal/nest/sysfs.go
@@ -1,6 +1,9 @@
 package nest
 
-import "github.com/mhemeryck/nest/internal/sysfs"
+import (
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/sysfs"
+)
 
 func sysfsChannels() (chan sysfs.Command, chan sysfs.StateChange, chan struct{}) {
 	commands := make(chan sysfs.Command, 32)
@@ -8,4 +11,12 @@ func sysfsChannels() (chan sysfs.Command, chan sysfs.StateChange, chan struct{})
 	done := make(chan struct{})
 
 	return commands, states, done
+}
+
+func sysfsPollIntervals(root *entity.Root) sysfs.PollIntervals {
+	return sysfs.PollIntervals{
+		DigitalInput:  root.SysfsPollIntervals.DigitalInput,
+		DigitalOutput: root.SysfsPollIntervals.DigitalOutput,
+		RelayOutput:   root.SysfsPollIntervals.RelayOutput,
+	}
 }

--- a/internal/sysfs/actor.go
+++ b/internal/sysfs/actor.go
@@ -18,10 +18,25 @@ type Command struct {
 	DeviceID string
 }
 
-func Run(ctx context.Context, devices []*Device, commands <-chan Command, states chan<- StateChange, done chan<- struct{}) {
+func Run(
+	ctx context.Context,
+	devices []*Device,
+	commands <-chan Command,
+	states chan<- StateChange,
+	done chan<- struct{},
+	intervals ...PollIntervals,
+) {
 	defer close(done)
 
-	configs := buildWorkerConfigs(devices)
+	configs := buildWorkerConfigs(devices, pollIntervals(intervals))
 	doneCh := startWorkers(ctx, configs, commands, states)
 	<-doneCh
+}
+
+func pollIntervals(intervals []PollIntervals) PollIntervals {
+	if len(intervals) == 0 {
+		return PollIntervals{}
+	}
+
+	return intervals[0]
 }

--- a/internal/sysfs/config.go
+++ b/internal/sysfs/config.go
@@ -7,14 +7,16 @@ type WorkerConfig struct {
 	Devices  []*Device
 }
 
-func buildWorkerConfigs(devices []*Device) []WorkerConfig {
+type PollIntervals struct {
+	DigitalInput  time.Duration
+	DigitalOutput time.Duration
+	RelayOutput   time.Duration
+}
+
+func buildWorkerConfigs(devices []*Device, intervals PollIntervals) []WorkerConfig {
 	configs := make(map[DeviceType]WorkerConfig)
 
-	defaultIntervals := map[DeviceType]time.Duration{
-		DigitalInput:  20 * time.Millisecond,
-		DigitalOutput: 100 * time.Millisecond,
-		RelayOutput:   1 * time.Second,
-	}
+	defaultIntervals := defaultPollIntervals(intervals)
 
 	for _, d := range devices {
 		cfg, ok := configs[d.Type]
@@ -31,4 +33,24 @@ func buildWorkerConfigs(devices []*Device) []WorkerConfig {
 	}
 
 	return result
+}
+
+func defaultPollIntervals(overrides PollIntervals) map[DeviceType]time.Duration {
+	intervals := map[DeviceType]time.Duration{
+		DigitalInput:  100 * time.Millisecond,
+		DigitalOutput: 100 * time.Millisecond,
+		RelayOutput:   1 * time.Second,
+	}
+
+	if overrides.DigitalInput > 0 {
+		intervals[DigitalInput] = overrides.DigitalInput
+	}
+	if overrides.DigitalOutput > 0 {
+		intervals[DigitalOutput] = overrides.DigitalOutput
+	}
+	if overrides.RelayOutput > 0 {
+		intervals[RelayOutput] = overrides.RelayOutput
+	}
+
+	return intervals
 }

--- a/internal/sysfs/config_test.go
+++ b/internal/sysfs/config_test.go
@@ -16,7 +16,7 @@ func TestBuildWorkerConfigs(t *testing.T) {
 		{Path: "/ro1", Type: RelayOutput, Identifier: "ro1"},
 	}
 
-	configs := buildWorkerConfigs(devices)
+	configs := buildWorkerConfigs(devices, PollIntervals{})
 
 	assert.Len(t, configs, 3)
 
@@ -37,10 +37,30 @@ func TestBuildWorkerConfigs(t *testing.T) {
 	diCfg, ok := configByType[DigitalInput]
 	require.True(t, ok)
 	assert.Len(t, diCfg.Devices, 2)
-	assert.Equal(t, 20*time.Millisecond, diCfg.Interval)
+	assert.Equal(t, 100*time.Millisecond, diCfg.Interval)
 
 	roCfg, ok := configByType[RelayOutput]
 	require.True(t, ok)
 	assert.Len(t, roCfg.Devices, 1)
 	assert.Equal(t, 1*time.Second, roCfg.Interval)
+}
+
+func TestBuildWorkerConfigsUsesPollIntervalOverrides(t *testing.T) {
+	devices := []*Device{
+		{Path: "/di1", Type: DigitalInput, Identifier: "di1"},
+		{Path: "/ro1", Type: RelayOutput, Identifier: "ro1"},
+	}
+
+	configs := buildWorkerConfigs(devices, PollIntervals{
+		DigitalInput: 250 * time.Millisecond,
+		RelayOutput:  2 * time.Second,
+	})
+
+	configByType := make(map[DeviceType]WorkerConfig)
+	for _, cfg := range configs {
+		configByType[cfg.Devices[0].Type] = cfg
+	}
+
+	assert.Equal(t, 250*time.Millisecond, configByType[DigitalInput].Interval)
+	assert.Equal(t, 2*time.Second, configByType[RelayOutput].Interval)
 }

--- a/internal/sysfs/worker_test.go
+++ b/internal/sysfs/worker_test.go
@@ -43,12 +43,12 @@ func TestPollWorkerDetectsChange(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 
 	err = writeValue(path1, On)
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 
 	cancel()
 	<-doneSysfs

--- a/test/fixtures/config.local-mqtt.yaml
+++ b/test/fixtures/config.local-mqtt.yaml
@@ -1,5 +1,9 @@
 sysfs:
   root: test/fixtures
+  poll_intervals:
+    digital_input: 100ms
+    digital_output: 250ms
+    relay_output: 1s
 
 mqtt:
   enabled: true

--- a/test/fixtures/config.local.yaml
+++ b/test/fixtures/config.local.yaml
@@ -1,5 +1,9 @@
 sysfs:
   root: test/fixtures
+  poll_intervals:
+    digital_input: 100ms
+    digital_output: 250ms
+    relay_output: 1s
 
 digital_inputs:
   - id: office_button_input


### PR DESCRIPTION
Allow sysfs poll intervals to be set from configuration while
keeping defaults for each device class. This relaxes the digital
input default to reduce CPU usage during passive observation.