### PR TITLE
Refactor runtime wiring

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -208,7 +208,7 @@ Next useful checks:
 
 **Deliverable**: The existing multi-unit light topology can be represented in the global config tree, projected into unit-local runtime indexes, and proven with MQTT-based semantic event sharing before Modbus execution is added.
 
-## Phase 7.5: Runtime Readability Refactor
+## Phase 7.1: Runtime Readability Refactor
 
 - [x] Simplify `internal/nest` startup flow so it reads as high-level runtime composition
 - [x] Group actor channel, topic, subscription, and shutdown wiring behind small runtime helpers
@@ -217,6 +217,16 @@ Next useful checks:
 - [x] Preserve existing behavior with tests before starting Modbus execution
 
 **Deliverable**: Runtime wiring is easier to read and extend before Modbus adds another transport path.
+
+## Phase 7.2: Runtime Registry Cleanup
+
+- [ ] Decide whether `registry.Index` should become a full runtime registry instead of a lookup-only index
+- [ ] Include canonical runtime data needed by actors and controllers in the registry when that reduces passing both `entity.Root` and `registry.Index`
+- [ ] Keep `entity.Root` as the config-to-domain translation result rather than making config parsing depend on runtime lookup concerns
+- [ ] Rename `registry.Index` if it starts owning canonical runtime data, for example to `registry.Registry`
+- [ ] Update runtime wiring so actors and controller code take the smallest coherent runtime dependency
+
+**Deliverable**: Runtime code no longer needs to pass both the canonical entity root and lookup index when a single registry better represents the unit-local runtime model.
 
 ## Phase 8: Modbus RTU Transport
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -208,6 +208,16 @@ Next useful checks:
 
 **Deliverable**: The existing multi-unit light topology can be represented in the global config tree, projected into unit-local runtime indexes, and proven with MQTT-based semantic event sharing before Modbus execution is added.
 
+## Phase 7.5: Runtime Readability Refactor
+
+- [x] Simplify `internal/nest` startup flow so it reads as high-level runtime composition
+- [x] Group actor channel, topic, subscription, and shutdown wiring behind small runtime helpers
+- [x] Keep config, entity, registry, controller, sysfs, and MQTT package boundaries unchanged unless a concrete dependency issue appears
+- [x] Make controller wiring easier to scan without introducing a generic context bag
+- [x] Preserve existing behavior with tests before starting Modbus execution
+
+**Deliverable**: Runtime wiring is easier to read and extend before Modbus adds another transport path.
+
 ## Phase 8: Modbus RTU Transport
 
 - [ ] Serial port configuration

--- a/internal/nest/devices.go
+++ b/internal/nest/devices.go
@@ -1,11 +1,47 @@
 package nest
 
 import (
+	"errors"
+	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
+
+func sysfsDevices(root *entity.Root, index *registry.Index) ([]*sysfs.Device, error) {
+	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
+	devices, err := sysfs.ListDevices(root.SysfsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("crawl sysfs: %w", err)
+	}
+
+	configured, missing := configuredDevices(devices, registry.SysfsDeviceIDs(index))
+	if len(missing) > 0 {
+		return nil, missingDevicesError(missing)
+	}
+
+	return configured, nil
+}
+
+func missingDevicesError(missing []entity.SysfsDeviceID) error {
+	var errs error
+	for _, deviceID := range missing {
+		slog.Error("configured device not found in sysfs", "device_id", deviceID)
+		errs = errors.Join(errs, fmt.Errorf("configured device %q not found in sysfs", deviceID))
+	}
+
+	return errs
+}
+
+func logSysfsDevices(devices []*sysfs.Device) {
+	slog.Info("configured devices", "count", len(devices))
+	for _, device := range devices {
+		slog.Info("configured device", "identifier", device.Identifier, "path", device.Path)
+	}
+}
 
 func configuredDevices(devices []*sysfs.Device, wanted []entity.SysfsDeviceID) ([]*sysfs.Device, []entity.SysfsDeviceID) {
 	byIdentifier := make(map[string]*sysfs.Device, len(devices))

--- a/internal/nest/mqtt.go
+++ b/internal/nest/mqtt.go
@@ -1,26 +1,51 @@
 package nest
 
 import (
+	"context"
+
 	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/mqtt"
 )
 
-func mqttChannels(root *entity.Root) (chan mqtt.Command, chan mqtt.Event, chan struct{}) {
-	if !root.MQTT.Enabled {
-		return nil, nil, nil
-	}
-
-	commands := make(chan mqtt.Command, 32)
-	events := make(chan mqtt.Event, 32)
-	done := make(chan struct{})
-
-	return commands, events, done
+type mqttActor struct {
+	commands          chan mqtt.Command
+	events            chan mqtt.Event
+	done              chan struct{}
+	topics            mqtt.Topics
+	sourceEventTopics []string
+	cfg               entity.MQTT
 }
 
-func mqttTopics(root *entity.Root) mqtt.Topics {
+func newMQTTActor(root *entity.Root) mqttActor {
 	if !root.MQTT.Enabled {
-		return mqtt.Topics{}
+		return mqttActor{}
 	}
 
-	return mqtt.NewTopics(root.MQTT.TopicPrefix, root.MQTT.UnitID)
+	topics := mqtt.NewTopics(root.MQTT.TopicPrefix, root.MQTT.UnitID)
+
+	return mqttActor{
+		commands:          make(chan mqtt.Command, 32),
+		events:            make(chan mqtt.Event, 32),
+		done:              make(chan struct{}),
+		topics:            topics,
+		sourceEventTopics: mqtt.SemanticSourceEventSubscriptionTopics(topics, root),
+		cfg:               root.MQTT,
+	}
+}
+
+func startMQTTActor(ctx context.Context, actor mqttActor) {
+	if actor.commands == nil {
+		return
+	}
+
+	go mqtt.Run(ctx, actor.cfg, actor.sourceEventTopics, actor.commands, actor.events, actor.done)
+}
+
+func waitForMQTTActor(actor mqttActor) {
+	if actor.done == nil {
+		return
+	}
+
+	<-actor.done
+	close(actor.events)
 }

--- a/internal/nest/mqtt.go
+++ b/internal/nest/mqtt.go
@@ -8,6 +8,7 @@ import (
 )
 
 type mqttActor struct {
+	enabled           bool
 	commands          chan mqtt.Command
 	events            chan mqtt.Event
 	done              chan struct{}
@@ -24,6 +25,7 @@ func newMQTTActor(root *entity.Root) mqttActor {
 	topics := mqtt.NewTopics(root.MQTT.TopicPrefix, root.MQTT.UnitID)
 
 	return mqttActor{
+		enabled:           true,
 		commands:          make(chan mqtt.Command, 32),
 		events:            make(chan mqtt.Event, 32),
 		done:              make(chan struct{}),
@@ -34,7 +36,7 @@ func newMQTTActor(root *entity.Root) mqttActor {
 }
 
 func startMQTTActor(ctx context.Context, actor mqttActor) {
-	if actor.commands == nil {
+	if !actor.enabled {
 		return
 	}
 
@@ -42,7 +44,7 @@ func startMQTTActor(ctx context.Context, actor mqttActor) {
 }
 
 func waitForMQTTActor(actor mqttActor) {
-	if actor.done == nil {
+	if !actor.enabled {
 		return
 	}
 

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -2,15 +2,11 @@ package nest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/mhemeryck/nest/internal/config"
-	"github.com/mhemeryck/nest/internal/controller"
-	"github.com/mhemeryck/nest/internal/mqtt"
 	"github.com/mhemeryck/nest/internal/registry"
-	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
 type Options struct {
@@ -38,55 +34,24 @@ func Run(ctx context.Context, opts Options) error {
 	root := config.ToEntityRoot(configRoot)
 	index := registry.Build(root)
 
-	// Resolve configured sysfs devices against the hardware tree before actors start.
-	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
-	devices, err := sysfs.ListDevices(root.SysfsRoot)
+	configuredDevices, err := sysfsDevices(root, index)
 	if err != nil {
-		return fmt.Errorf("crawl sysfs: %w", err)
+		return err
 	}
-
-	configuredDevices, missing := configuredDevices(devices, registry.SysfsDeviceIDs(index))
-	if len(missing) > 0 {
-		var errs error
-		for _, deviceID := range missing {
-			slog.Error("configured device not found in sysfs", "device_id", deviceID)
-			errs = errors.Join(errs, fmt.Errorf("configured device %q not found in sysfs", deviceID))
-		}
-		return errs
-	}
-
-	slog.Info("configured devices", "count", len(configuredDevices))
-	for _, device := range configuredDevices {
-		slog.Info("configured device", "identifier", device.Identifier, "path", device.Path)
-	}
+	logSysfsDevices(configuredDevices)
 	logModbusConfig(root)
 
-	// Start optional transport actors before local control so startup state is published early.
-	mqttCommands, mqttEvents, mqttDone := mqttChannels(root)
-	if mqttCommands != nil {
-		go mqtt.Run(ctx, root.MQTT, mqtt.SemanticSourceEventSubscriptionTopics(mqttTopics(root), root), mqttCommands, mqttEvents, mqttDone)
-	}
+	mqttActor := newMQTTActor(root)
+	sysfsActor := newSysfsActor(root, configuredDevices)
 
-	// Start hardware and controller actors with unidirectional command and observation channels.
-	sysfsCommands, states, sysfsDone := sysfsChannels()
-	go sysfs.Run(ctx, configuredDevices, sysfsCommands, states, sysfsDone, sysfsPollIntervals(root))
+	startMQTTActor(ctx, mqttActor)
+	startSysfsActor(ctx, sysfsActor)
 
-	controllerDone := make(chan struct{})
-	go controller.Run(ctx, root, index, sysfsCommands, mqttCommands, mqttTopics(root), states, mqttEvents, controllerDone)
+	controllerDone := startController(ctx, root, index, sysfsActor, mqttActor)
 
-	slog.Info("polling devices", "message", "press Ctrl+C to exit")
+	slog.Info("runtime started", "message", "press Ctrl+C to exit")
 
-	// Controller shutdown drives process shutdown and then actors are drained in order.
-	<-controllerDone
-	cancel()
-	<-sysfsDone
-	close(states)
-	if mqttDone != nil {
-		<-mqttDone
-	}
-	if mqttEvents != nil {
-		close(mqttEvents)
-	}
+	waitForShutdown(cancel, controllerDone, sysfsActor, mqttActor)
 
 	slog.Info("shutting down")
 	return nil

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/mhemeryck/nest/internal/config"
+	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/registry"
 )
 
@@ -19,10 +20,9 @@ func Run(ctx context.Context, opts Options) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Load and validate external configuration before building runtime state.
-	configRoot, err := config.Load(opts.ConfigPath, opts.UnitID)
+	root, index, err := loadConfig(opts)
 	if err != nil {
-		return fmt.Errorf("load config: %w", err)
+		return err
 	}
 
 	if opts.ValidateOnly {
@@ -30,19 +30,12 @@ func Run(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	// Translate config into domain entities and indexes used by controllers.
-	root := config.ToEntityRoot(configRoot)
-	index := registry.Build(root)
-
-	configuredDevices, err := sysfsDevices(root, index)
+	mqttActor := newMQTTActor(root)
+	sysfsActor, err := newSysfsActor(root, index)
 	if err != nil {
 		return err
 	}
-	logSysfsDevices(configuredDevices)
 	logModbusConfig(root)
-
-	mqttActor := newMQTTActor(root)
-	sysfsActor := newSysfsActor(root, configuredDevices)
 
 	startMQTTActor(ctx, mqttActor)
 	startSysfsActor(ctx, sysfsActor)
@@ -55,4 +48,16 @@ func Run(ctx context.Context, opts Options) error {
 
 	slog.Info("shutting down")
 	return nil
+}
+
+func loadConfig(opts Options) (*entity.Root, *registry.Index, error) {
+	configRoot, err := config.Load(opts.ConfigPath, opts.UnitID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load config: %w", err)
+	}
+
+	root := config.ToEntityRoot(configRoot)
+	index := registry.Build(root)
+
+	return root, index, nil
 }

--- a/internal/nest/runtime.go
+++ b/internal/nest/runtime.go
@@ -1,0 +1,44 @@
+package nest
+
+import (
+	"context"
+
+	"github.com/mhemeryck/nest/internal/controller"
+	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/registry"
+)
+
+func startController(
+	ctx context.Context,
+	root *entity.Root,
+	index *registry.Index,
+	sysfsActor sysfsActor,
+	mqttActor mqttActor,
+) <-chan struct{} {
+	done := make(chan struct{})
+	go controller.Run(
+		ctx,
+		root,
+		index,
+		sysfsActor.commands,
+		mqttActor.commands,
+		mqttActor.topics,
+		sysfsActor.states,
+		mqttActor.events,
+		done,
+	)
+
+	return done
+}
+
+func waitForShutdown(
+	cancel context.CancelFunc,
+	controllerDone <-chan struct{},
+	sysfsActor sysfsActor,
+	mqttActor mqttActor,
+) {
+	<-controllerDone
+	cancel()
+	waitForSysfsActor(sysfsActor)
+	waitForMQTTActor(mqttActor)
+}

--- a/internal/nest/sysfs.go
+++ b/internal/nest/sysfs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
@@ -15,14 +16,20 @@ type sysfsActor struct {
 	pollIntervals sysfs.PollIntervals
 }
 
-func newSysfsActor(root *entity.Root, devices []*sysfs.Device) sysfsActor {
+func newSysfsActor(root *entity.Root, index *registry.Index) (sysfsActor, error) {
+	devices, err := sysfsDevices(root, index)
+	if err != nil {
+		return sysfsActor{}, err
+	}
+	logSysfsDevices(devices)
+
 	return sysfsActor{
 		commands:      make(chan sysfs.Command, 32),
 		states:        make(chan sysfs.StateChange, 32),
 		done:          make(chan struct{}),
 		devices:       devices,
 		pollIntervals: sysfsPollIntervals(root),
-	}
+	}, nil
 }
 
 func startSysfsActor(ctx context.Context, actor sysfsActor) {

--- a/internal/nest/sysfs.go
+++ b/internal/nest/sysfs.go
@@ -1,16 +1,37 @@
 package nest
 
 import (
+	"context"
+
 	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
-func sysfsChannels() (chan sysfs.Command, chan sysfs.StateChange, chan struct{}) {
-	commands := make(chan sysfs.Command, 32)
-	states := make(chan sysfs.StateChange, 32)
-	done := make(chan struct{})
+type sysfsActor struct {
+	commands      chan sysfs.Command
+	states        chan sysfs.StateChange
+	done          chan struct{}
+	devices       []*sysfs.Device
+	pollIntervals sysfs.PollIntervals
+}
 
-	return commands, states, done
+func newSysfsActor(root *entity.Root, devices []*sysfs.Device) sysfsActor {
+	return sysfsActor{
+		commands:      make(chan sysfs.Command, 32),
+		states:        make(chan sysfs.StateChange, 32),
+		done:          make(chan struct{}),
+		devices:       devices,
+		pollIntervals: sysfsPollIntervals(root),
+	}
+}
+
+func startSysfsActor(ctx context.Context, actor sysfsActor) {
+	go sysfs.Run(ctx, actor.devices, actor.commands, actor.states, actor.done, actor.pollIntervals)
+}
+
+func waitForSysfsActor(actor sysfsActor) {
+	<-actor.done
+	close(actor.states)
 }
 
 func sysfsPollIntervals(root *entity.Root) sysfs.PollIntervals {


### PR DESCRIPTION
Simplify the nest composition root before adding Modbus.
Actor channel setup, topic derivation, sysfs device resolution, and
shutdown are grouped behind small helpers while preserving existing
package boundaries.

Document the follow-up registry cleanup separately so the later
runtime data-model change stays scoped.
