### PR TITLE
Clean up runtime registry wiring

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -221,7 +221,7 @@ Next useful checks:
 ## Phase 7.2: Runtime Registry Cleanup
 
 - [x] Decide that `registry.Index` should become a runtime registry rather than a lookup-only index
-- [ ] Rename `registry.Index` to `registry.Registry`
+- [x] Rename `registry.Index` to `registry.Registry`
 - [ ] Keep `entity.Root` as the bare projected domain model with entity lists, bindings, and config-derived settings
 - [ ] Use `registry.Registry` as the runtime translation catalog built from `entity.Root`
 - [ ] Include runtime data needed by actors and controllers in `registry.Registry` when it avoids passing both `entity.Root` and the registry

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -220,13 +220,26 @@ Next useful checks:
 
 ## Phase 7.2: Runtime Registry Cleanup
 
-- [ ] Decide whether `registry.Index` should become a full runtime registry instead of a lookup-only index
-- [ ] Include canonical runtime data needed by actors and controllers in the registry when that reduces passing both `entity.Root` and `registry.Index`
-- [ ] Keep `entity.Root` as the config-to-domain translation result rather than making config parsing depend on runtime lookup concerns
-- [ ] Rename `registry.Index` if it starts owning canonical runtime data, for example to `registry.Registry`
-- [ ] Update runtime wiring so actors and controller code take the smallest coherent runtime dependency
+- [x] Decide that `registry.Index` should become a runtime registry rather than a lookup-only index
+- [ ] Rename `registry.Index` to `registry.Registry`
+- [ ] Keep `entity.Root` as the bare projected domain model with entity lists, bindings, and config-derived settings
+- [ ] Use `registry.Registry` as the runtime translation catalog built from `entity.Root`
+- [ ] Include runtime data needed by actors and controllers in `registry.Registry` when it avoids passing both `entity.Root` and the registry
+- [ ] Keep registry fields private and expose package-level functions that take `reg *registry.Registry`
+- [ ] Return copied slices from registry functions so callers do not mutate registry-owned data accidentally
+- [ ] Update `internal/nest` runtime wiring to pass one explicit `reg` value into actor and controller setup
+- [ ] Update controller code to depend on `reg *registry.Registry` instead of both `root *entity.Root` and `index *registry.Index`
+- [ ] Keep MQTT topic generation and protocol-specific behavior in the MQTT package rather than moving actor-specific addressing into the registry
 
-**Deliverable**: Runtime code no longer needs to pass both the canonical entity root and lookup index when a single registry better represents the unit-local runtime model.
+Current direction:
+
+- `entity.Root` is the bare projected domain model produced by config-to-entity translation
+- `registry.Registry` is the runtime lookup and translation catalog built from `entity.Root`
+- `internal/nest` remains responsible for runtime composition, actor lifecycle, channel wiring, startup, and shutdown
+- controller code uses the registry to translate observations and semantic events into follow-up events or actor commands
+- actor packages keep ownership of external protocol details such as MQTT topics, sysfs crawling, and future Modbus transport addresses
+
+**Deliverable**: Runtime code no longer needs to pass both the canonical entity root and lookup index when a single registry better represents the unit-local translation catalog.
 
 ## Phase 8: Modbus RTU Transport
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -222,11 +222,11 @@ Next useful checks:
 
 - [x] Decide that `registry.Index` should become a runtime registry rather than a lookup-only index
 - [x] Rename `registry.Index` to `registry.Registry`
-- [ ] Keep `entity.Root` as the bare projected domain model with entity lists, bindings, and config-derived settings
+- [x] Keep `entity.Root` as the bare projected domain model with entity lists, bindings, and config-derived settings
 - [ ] Use `registry.Registry` as the runtime translation catalog built from `entity.Root`
-- [ ] Include runtime data needed by actors and controllers in `registry.Registry` when it avoids passing both `entity.Root` and the registry
+- [x] Include runtime data needed by actors and controllers in `registry.Registry` when it avoids passing both `entity.Root` and the registry
 - [ ] Keep registry fields private and expose package-level functions that take `reg *registry.Registry`
-- [ ] Return copied slices from registry functions so callers do not mutate registry-owned data accidentally
+- [x] Return copied slices from registry functions so callers do not mutate registry-owned data accidentally
 - [ ] Update `internal/nest` runtime wiring to pass one explicit `reg` value into actor and controller setup
 - [ ] Update controller code to depend on `reg *registry.Registry` instead of both `root *entity.Root` and `index *registry.Index`
 - [ ] Keep MQTT topic generation and protocol-specific behavior in the MQTT package rather than moving actor-specific addressing into the registry

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -223,13 +223,13 @@ Next useful checks:
 - [x] Decide that `registry.Index` should become a runtime registry rather than a lookup-only index
 - [x] Rename `registry.Index` to `registry.Registry`
 - [x] Keep `entity.Root` as the bare projected domain model with entity lists, bindings, and config-derived settings
-- [ ] Use `registry.Registry` as the runtime translation catalog built from `entity.Root`
+- [x] Use `registry.Registry` as the runtime translation catalog built from `entity.Root`
 - [x] Include runtime data needed by actors and controllers in `registry.Registry` when it avoids passing both `entity.Root` and the registry
 - [ ] Keep registry fields private and expose package-level functions that take `reg *registry.Registry`
 - [x] Return copied slices from registry functions so callers do not mutate registry-owned data accidentally
-- [ ] Update `internal/nest` runtime wiring to pass one explicit `reg` value into actor and controller setup
-- [ ] Update controller code to depend on `reg *registry.Registry` instead of both `root *entity.Root` and `index *registry.Index`
-- [ ] Keep MQTT topic generation and protocol-specific behavior in the MQTT package rather than moving actor-specific addressing into the registry
+- [x] Update `internal/nest` runtime wiring to pass one explicit `reg` value into actor and controller setup
+- [x] Update controller code to depend on `reg *registry.Registry` instead of both `root *entity.Root` and `index *registry.Index`
+- [x] Keep MQTT topic generation and protocol-specific behavior in the MQTT package rather than moving actor-specific addressing into the registry
 
 Current direction:
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -225,7 +225,7 @@ Next useful checks:
 - [x] Keep `entity.Root` as the bare projected domain model with entity lists, bindings, and config-derived settings
 - [x] Use `registry.Registry` as the runtime translation catalog built from `entity.Root`
 - [x] Include runtime data needed by actors and controllers in `registry.Registry` when it avoids passing both `entity.Root` and the registry
-- [ ] Keep registry fields private and expose package-level functions that take `reg *registry.Registry`
+- [x] Keep registry fields private and expose package-level functions that take `reg *registry.Registry`
 - [x] Return copied slices from registry functions so callers do not mutate registry-owned data accidentally
 - [x] Update `internal/nest` runtime wiring to pass one explicit `reg` value into actor and controller setup
 - [x] Update controller code to depend on `reg *registry.Registry` instead of both `root *entity.Root` and `index *registry.Index`

--- a/internal/controller/binding.go
+++ b/internal/controller/binding.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mhemeryck/nest/internal/registry"
 )
 
-func bindingEventsFromEvent(index *registry.Index, busEvent event.Event) []event.Event {
+func bindingEventsFromEvent(index *registry.Registry, busEvent event.Event) []event.Event {
 	switch busEvent.Kind {
 	case event.PushButtonPressedKind:
 		return lightEventsFromPushButton(index, *busEvent.PushButton)
@@ -15,7 +15,7 @@ func bindingEventsFromEvent(index *registry.Index, busEvent event.Event) []event
 	}
 }
 
-func lightEventsFromPushButton(index *registry.Index, pushButton event.PushButton) []event.Event {
+func lightEventsFromPushButton(index *registry.Registry, pushButton event.PushButton) []event.Event {
 	bindings := registry.BindingsByButton(index, pushButton.ButtonID)
 	bindings = append(bindings, registry.RemoteTargetBindingsByButton(index, pushButton.ButtonID)...)
 	lightEvents := make([]event.Event, 0, len(bindings))

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -17,7 +17,7 @@ import (
 func Run(
 	ctx context.Context,
 	root *entity.Root,
-	index *registry.Index,
+	index *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
 	mqttTopics mqtt.Topics,
@@ -36,7 +36,7 @@ func Run(
 
 func normalizeEvents(
 	ctx context.Context,
-	index *registry.Index,
+	index *registry.Registry,
 	mqttTopics mqtt.Topics,
 	stateChanges <-chan sysfs.StateChange,
 	mqttEvents <-chan mqtt.Event,
@@ -73,7 +73,7 @@ func normalizeEvents(
 
 func normalizeStateChanges(
 	ctx context.Context,
-	index *registry.Index,
+	index *registry.Registry,
 	stateChanges <-chan sysfs.StateChange,
 	semanticEvents chan<- event.Event,
 ) {
@@ -91,7 +91,7 @@ func normalizeStateChanges(
 	}
 }
 
-func normalizeMQTTEvents(ctx context.Context, index *registry.Index, mqttTopics mqtt.Topics, mqttEvents <-chan mqtt.Event, semanticEvents chan<- event.Event) {
+func normalizeMQTTEvents(ctx context.Context, index *registry.Registry, mqttTopics mqtt.Topics, mqttEvents <-chan mqtt.Event, semanticEvents chan<- event.Event) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -112,7 +112,7 @@ func normalizeMQTTEvents(ctx context.Context, index *registry.Index, mqttTopics 
 func dispatchEvents(
 	ctx context.Context,
 	root *entity.Root,
-	index *registry.Index,
+	index *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
 	mqttTopics mqtt.Topics,
@@ -170,7 +170,7 @@ func publishMQTTStartup(ctx context.Context, root *entity.Root, commands chan<- 
 	return nil
 }
 
-func semanticEventFromMQTTEvent(index *registry.Index, mqttTopics mqtt.Topics, mqttEvent mqtt.Event) (event.Event, bool) {
+func semanticEventFromMQTTEvent(index *registry.Registry, mqttTopics mqtt.Topics, mqttEvent mqtt.Event) (event.Event, bool) {
 	semanticEvent := event.Event{MQTT: &event.MQTT{PublishTopic: mqttEvent.Publish.Topic, Error: mqttEvent.Error}}
 	switch mqttEvent.Kind {
 	case mqtt.ConnectedEventKind:
@@ -192,7 +192,7 @@ func semanticEventFromMQTTEvent(index *registry.Index, mqttTopics mqtt.Topics, m
 	return semanticEvent, true
 }
 
-func semanticEventFromMQTTMessage(index *registry.Index, mqttTopics mqtt.Topics, message mqtt.ReceivedMessage) (event.Event, bool) {
+func semanticEventFromMQTTMessage(index *registry.Registry, mqttTopics mqtt.Topics, message mqtt.ReceivedMessage) (event.Event, bool) {
 	if semanticEvent, ok := semanticLightEventFromMQTTMessage(index, mqttTopics, message); ok {
 		return semanticEvent, true
 	}
@@ -200,7 +200,7 @@ func semanticEventFromMQTTMessage(index *registry.Index, mqttTopics mqtt.Topics,
 	return semanticSourceEventFromMQTTMessage(index, mqttTopics, message)
 }
 
-func semanticLightEventFromMQTTMessage(index *registry.Index, mqttTopics mqtt.Topics, message mqtt.ReceivedMessage) (event.Event, bool) {
+func semanticLightEventFromMQTTMessage(index *registry.Registry, mqttTopics mqtt.Topics, message mqtt.ReceivedMessage) (event.Event, bool) {
 	lightID, ok := mqtt.ParseLightCommandTopic(mqttTopics, message.Topic)
 	if !ok {
 		return event.Event{}, false
@@ -228,7 +228,7 @@ func semanticLightEventFromMQTTMessage(index *registry.Index, mqttTopics mqtt.To
 	}, true
 }
 
-func semanticSourceEventFromMQTTMessage(index *registry.Index, mqttTopics mqtt.Topics, message mqtt.ReceivedMessage) (event.Event, bool) {
+func semanticSourceEventFromMQTTMessage(index *registry.Registry, mqttTopics mqtt.Topics, message mqtt.ReceivedMessage) (event.Event, bool) {
 	sourceEvent, ok := mqtt.ParseSemanticSourceEventMessage(message, mqttTopics.Prefix)
 	if !ok {
 		slog.Warn("unhandled mqtt message topic", "topic", message.Topic)
@@ -264,7 +264,7 @@ func lightActionFromMQTTPayload(payload []byte) (entity.LightAction, bool) {
 	}
 }
 
-func normalizeStateChange(ctx context.Context, index *registry.Index, semanticEvents chan<- event.Event, stateChange sysfs.StateChange) {
+func normalizeStateChange(ctx context.Context, index *registry.Registry, semanticEvents chan<- event.Event, stateChange sysfs.StateChange) {
 	events, handled := semanticEventsFromStateChange(index, stateChange)
 	if handled {
 		for _, semanticEvent := range events {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -44,38 +44,6 @@ func normalizeEvents(
 ) {
 	defer close(done)
 	defer close(semanticEvents)
-	normalizerCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	normalizerDone := make(chan struct{}, 2)
-
-	go func() {
-		normalizeStateChanges(normalizerCtx, index, stateChanges, semanticEvents)
-		normalizerDone <- struct{}{}
-	}()
-	go func() {
-		normalizeMQTTEvents(normalizerCtx, index, mqttTopics, mqttEvents, semanticEvents)
-		normalizerDone <- struct{}{}
-	}()
-
-	completed := 0
-	select {
-	case <-ctx.Done():
-	case <-normalizerDone:
-		completed++
-	}
-	cancel()
-	for completed < 2 {
-		<-normalizerDone
-		completed++
-	}
-}
-
-func normalizeStateChanges(
-	ctx context.Context,
-	index *registry.Registry,
-	stateChanges <-chan sysfs.StateChange,
-	semanticEvents chan<- event.Event,
-) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -86,15 +54,6 @@ func normalizeStateChanges(
 			}
 
 			normalizeStateChange(ctx, index, semanticEvents, stateChange)
-		}
-	}
-}
-
-func normalizeMQTTEvents(ctx context.Context, index *registry.Registry, mqttTopics mqtt.Topics, mqttEvents <-chan mqtt.Event, semanticEvents chan<- event.Event) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
 		case mqttEvent, ok := <-mqttEvents:
 			if !ok {
 				return

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -16,8 +16,7 @@ import (
 
 func Run(
 	ctx context.Context,
-	root *entity.Root,
-	index *registry.Registry,
+	reg *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
 	mqttTopics mqtt.Topics,
@@ -28,9 +27,9 @@ func Run(
 	defer close(done)
 	semanticEvents := make(chan event.Event, 32)
 	normalizerDone := make(chan struct{})
-	go normalizeEvents(ctx, index, mqttTopics, stateChanges, mqttEvents, semanticEvents, normalizerDone)
+	go normalizeEvents(ctx, reg, mqttTopics, stateChanges, mqttEvents, semanticEvents, normalizerDone)
 
-	dispatchEvents(ctx, root, index, sysfsCommands, mqttCommands, mqttTopics, semanticEvents)
+	dispatchEvents(ctx, reg, sysfsCommands, mqttCommands, mqttTopics, semanticEvents)
 	<-normalizerDone
 }
 
@@ -111,8 +110,7 @@ func normalizeMQTTEvents(ctx context.Context, index *registry.Registry, mqttTopi
 
 func dispatchEvents(
 	ctx context.Context,
-	root *entity.Root,
-	index *registry.Registry,
+	reg *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
 	mqttTopics mqtt.Topics,
@@ -123,7 +121,7 @@ func dispatchEvents(
 
 	for {
 		if semanticEvent, remainingEvents, ok := popEvent(dispatchQueue); ok {
-			dispatchQueue = append(remainingEvents, dispatchEvent(ctx, root, index, sysfsCommands, mqttCommands, mqttTopics, semanticEvent)...)
+			dispatchQueue = append(remainingEvents, dispatchEvent(ctx, reg, sysfsCommands, mqttCommands, mqttTopics, semanticEvent)...)
 			continue
 		}
 
@@ -153,8 +151,8 @@ func popEvent(events []event.Event) (event.Event, []event.Event, bool) {
 	return events[0], events[1:], true
 }
 
-func publishMQTTStartup(ctx context.Context, root *entity.Root, commands chan<- mqtt.Command) error {
-	startupCommands, err := mqtt.StartupCommands(root)
+func publishMQTTStartup(ctx context.Context, reg *registry.Registry, commands chan<- mqtt.Command) error {
+	startupCommands, err := mqtt.StartupCommands(registry.MQTT(reg), registry.Lights(reg))
 	if err != nil {
 		return fmt.Errorf("build mqtt startup commands: %w", err)
 	}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -428,7 +428,7 @@ func captureLogs(t *testing.T, fn func()) string {
 func dispatchQueuedTestEvents(
 	ctx context.Context,
 	root *entity.Root,
-	index *registry.Index,
+	index *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
 	mqttTopics mqtt.Topics,

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -25,7 +25,7 @@ func TestRunReturnsOnSignal(t *testing.T) {
 	stateChanges := make(chan sysfs.StateChange)
 	commands := make(chan sysfs.Command)
 	done := make(chan struct{})
-	go Run(ctx, &entity.Root{}, index, commands, nil, mqtt.Topics{}, stateChanges, nil, done)
+	go Run(ctx, index, commands, nil, mqtt.Topics{}, stateChanges, nil, done)
 
 	cancel()
 
@@ -42,7 +42,7 @@ func TestRunReturnsWhenPollEventsClose(t *testing.T) {
 	stateChanges := make(chan sysfs.StateChange)
 	commands := make(chan sysfs.Command)
 	done := make(chan struct{})
-	go Run(ctx, &entity.Root{}, index, commands, nil, mqtt.Topics{}, stateChanges, nil, done)
+	go Run(ctx, index, commands, nil, mqtt.Topics{}, stateChanges, nil, done)
 
 	close(stateChanges)
 
@@ -67,7 +67,7 @@ func TestDispatchPushButtonEventTogglesLightRelay(t *testing.T) {
 	commands := make(chan sysfs.Command, 1)
 
 	logs := captureLogs(t, func() {
-		dispatchQueuedTestEvents(t.Context(), &entity.Root{}, index, commands, nil, mqtt.Topics{}, event.Event{
+		dispatchQueuedTestEvents(t.Context(), index, commands, nil, mqtt.Topics{}, event.Event{
 			Kind: event.PushButtonPressedKind,
 			PushButton: &event.PushButton{
 				ButtonID: entity.PushButtonID("office_button"),
@@ -97,7 +97,7 @@ func TestDispatchPushButtonEventDerivesLightEvent(t *testing.T) {
 	})
 	sysfsCommands := make(chan sysfs.Command, 1)
 
-	derivedEvents := dispatchEvent(t.Context(), &entity.Root{}, index, sysfsCommands, nil, mqtt.Topics{}, event.Event{
+	derivedEvents := dispatchEvent(t.Context(), index, sysfsCommands, nil, mqtt.Topics{}, event.Event{
 		Kind: event.PushButtonPressedKind,
 		PushButton: &event.PushButton{
 			ButtonID: entity.PushButtonID("office_button"),
@@ -131,7 +131,7 @@ func TestHandleStateChangeDoesNotPublishRawInputOrButtonState(t *testing.T) {
 		NewValue: sysfs.On,
 		IsRising: true,
 	})
-	dispatchQueuedTestEvents(t.Context(), &entity.Root{}, index, sysfsCommands, mqttCommands, topics, <-semanticEvents, <-semanticEvents)
+	dispatchQueuedTestEvents(t.Context(), index, sysfsCommands, mqttCommands, topics, <-semanticEvents, <-semanticEvents)
 
 	assert.Empty(t, mqttCommands)
 
@@ -162,7 +162,7 @@ func TestProjectedConfigStateChangeTogglesLocalLight(t *testing.T) {
 	assert.Equal(t, event.PushButtonPressedKind, buttonEvent.Kind)
 	assert.Equal(t, entity.PushButtonID("controller_1.button.office_button"), buttonEvent.PushButton.ButtonID)
 
-	dispatchQueuedTestEvents(t.Context(), root, index, sysfsCommands, mqttCommands, mqtt.NewTopics("nest", "controller_1"), inputEvent, buttonEvent)
+	dispatchQueuedTestEvents(t.Context(), index, sysfsCommands, mqttCommands, mqtt.NewTopics("nest", "controller_1"), inputEvent, buttonEvent)
 
 	assert.Empty(t, mqttCommands)
 	sysfsCommand := <-sysfsCommands
@@ -182,7 +182,7 @@ func TestDispatchPushButtonEventPublishesRemoteSourceEvent(t *testing.T) {
 	index := registry.Build(root)
 	mqttCommands := make(chan mqtt.Command, 1)
 
-	dispatchEvent(t.Context(), root, index, nil, mqttCommands, mqtt.NewTopics("nest", "controller_1"), event.Event{
+	dispatchEvent(t.Context(), index, nil, mqttCommands, mqtt.NewTopics("nest", "controller_1"), event.Event{
 		Kind: event.PushButtonPressedKind,
 		PushButton: &event.PushButton{
 			ButtonID: entity.PushButtonID("controller_1.button.office_button"),
@@ -209,14 +209,14 @@ func TestDispatchRemoteSourceEventTogglesTargetLocalLight(t *testing.T) {
 	})
 	sysfsCommands := make(chan sysfs.Command, 1)
 
-	derivedEvents := dispatchEvent(t.Context(), &entity.Root{}, index, sysfsCommands, nil, mqtt.Topics{}, event.Event{
+	derivedEvents := dispatchEvent(t.Context(), index, sysfsCommands, nil, mqtt.Topics{}, event.Event{
 		Kind: event.PushButtonPressedKind,
 		PushButton: &event.PushButton{
 			ButtonID: entity.PushButtonID("controller_2.button.hall_button"),
 		},
 	})
 	require.Len(t, derivedEvents, 1)
-	dispatchEvent(t.Context(), &entity.Root{}, index, sysfsCommands, nil, mqtt.Topics{}, derivedEvents[0])
+	dispatchEvent(t.Context(), index, sysfsCommands, nil, mqtt.Topics{}, derivedEvents[0])
 
 	command := <-sysfsCommands
 	assert.Equal(t, sysfs.ToggleCommand, command.Kind)
@@ -238,8 +238,8 @@ func TestHandleStateChangePublishesMappedLightState(t *testing.T) {
 		NewValue: sysfs.On,
 		IsRising: true,
 	})
-	dispatchEvent(t.Context(), &entity.Root{}, index, nil, mqttCommands, topics, <-semanticEvents)
-	dispatchEvent(t.Context(), &entity.Root{}, index, nil, mqttCommands, topics, <-semanticEvents)
+	dispatchEvent(t.Context(), index, nil, mqttCommands, topics, <-semanticEvents)
+	dispatchEvent(t.Context(), index, nil, mqttCommands, topics, <-semanticEvents)
 
 	lightCommand := <-mqttCommands
 	assert.Equal(t, mqtt.PublishCommandKind, lightCommand.Kind)
@@ -275,7 +275,7 @@ func TestNormalizeMQTTEventPublishesStartupCommandsOnConnect(t *testing.T) {
 	semanticEvent, handled := semanticEventFromMQTTEvent(registry.Build(root), mqtt.Topics{}, mqtt.ConnectedEvent())
 	require.True(t, handled)
 
-	dispatchEvent(t.Context(), root, registry.Build(root), nil, commands, mqtt.Topics{}, semanticEvent)
+	dispatchEvent(t.Context(), registry.Build(root), nil, commands, mqtt.Topics{}, semanticEvent)
 
 	require.Len(t, commands, 2)
 	assert.Equal(t, "homeassistant/device/nest_controller_1_unit/config", (<-commands).Publish.Topic)
@@ -287,7 +287,7 @@ func TestNormalizeMQTTEventIgnoresNonConnectEvents(t *testing.T) {
 	semanticEvent, handled := semanticEventFromMQTTEvent(registry.Build(&entity.Root{}), mqtt.Topics{}, mqtt.PublishedEvent(mqtt.PublishMessage{Topic: "nest/topic"}))
 	require.True(t, handled)
 
-	dispatchEvent(t.Context(), &entity.Root{}, registry.Build(&entity.Root{}), nil, commands, mqtt.Topics{}, semanticEvent)
+	dispatchEvent(t.Context(), registry.Build(&entity.Root{}), nil, commands, mqtt.Topics{}, semanticEvent)
 
 	assert.Empty(t, commands)
 }
@@ -299,7 +299,7 @@ func TestDispatchMQTTLightCommandTurnsLightOn(t *testing.T) {
 	})
 	commands := make(chan sysfs.Command, 1)
 
-	dispatchEvent(t.Context(), &entity.Root{}, index, commands, nil, mqtt.Topics{}, event.Event{
+	dispatchEvent(t.Context(), index, commands, nil, mqtt.Topics{}, event.Event{
 		Kind: event.LightKind,
 		Light: &event.Light{
 			LightID: entity.LightID("office_light"),
@@ -327,7 +327,7 @@ func TestProjectedConfigMQTTLightCommandTurnsLightOn(t *testing.T) {
 	require.True(t, handled)
 	assert.Equal(t, entity.LightID("controller_1.light.office_light"), semanticEvent.Light.LightID)
 
-	dispatchEvent(t.Context(), root, registry.Build(root), commands, nil, mqtt.Topics{}, semanticEvent)
+	dispatchEvent(t.Context(), registry.Build(root), commands, nil, mqtt.Topics{}, semanticEvent)
 
 	command := <-commands
 	assert.Equal(t, sysfs.OnCommand, command.Kind)
@@ -368,7 +368,7 @@ func TestHandleStateChangeLogsPushButtonRelease(t *testing.T) {
 			NewValue: sysfs.Off,
 			IsRising: false,
 		})
-		dispatchQueuedTestEvents(t.Context(), &entity.Root{}, index, nil, nil, mqtt.Topics{}, <-semanticEvents, <-semanticEvents)
+		dispatchQueuedTestEvents(t.Context(), index, nil, nil, mqtt.Topics{}, <-semanticEvents, <-semanticEvents)
 	})
 
 	assert.Contains(t, logs, "push button event")
@@ -427,7 +427,6 @@ func captureLogs(t *testing.T, fn func()) string {
 
 func dispatchQueuedTestEvents(
 	ctx context.Context,
-	root *entity.Root,
 	index *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
@@ -440,5 +439,5 @@ func dispatchQueuedTestEvents(
 	}
 	close(semanticEvents)
 
-	dispatchEvents(ctx, root, index, sysfsCommands, mqttCommands, mqttTopics, semanticEvents)
+	dispatchEvents(ctx, index, sysfsCommands, mqttCommands, mqttTopics, semanticEvents)
 }

--- a/internal/controller/dispatch.go
+++ b/internal/controller/dispatch.go
@@ -13,17 +13,16 @@ import (
 
 func dispatchEvent(
 	ctx context.Context,
-	root *entity.Root,
-	index *registry.Registry,
+	reg *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
 	mqttTopics mqtt.Topics,
 	busEvent event.Event,
 ) []event.Event {
 	logSemanticEvent(busEvent)
-	derivedEvents := bindingEventsFromEvent(index, busEvent)
-	dispatchSysfsCommand(ctx, index, sysfsCommands, busEvent)
-	dispatchMQTTCommand(ctx, root, index, mqttCommands, mqttTopics, busEvent)
+	derivedEvents := bindingEventsFromEvent(reg, busEvent)
+	dispatchSysfsCommand(ctx, reg, sysfsCommands, busEvent)
+	dispatchMQTTCommand(ctx, reg, mqttCommands, mqttTopics, busEvent)
 
 	return derivedEvents
 }
@@ -35,14 +34,14 @@ func dispatchSysfsCommand(ctx context.Context, index *registry.Registry, command
 	}
 }
 
-func dispatchMQTTCommand(ctx context.Context, root *entity.Root, index *registry.Registry, commands chan<- mqtt.Command, topics mqtt.Topics, busEvent event.Event) {
+func dispatchMQTTCommand(ctx context.Context, reg *registry.Registry, commands chan<- mqtt.Command, topics mqtt.Topics, busEvent event.Event) {
 	switch busEvent.Kind {
 	case event.PushButtonPressedKind, event.PushButtonReleasedKind:
-		publishPushButtonSourceEvent(ctx, index, commands, topics, busEvent.Kind, *busEvent.PushButton)
+		publishPushButtonSourceEvent(ctx, reg, commands, topics, busEvent.Kind, *busEvent.PushButton)
 	case event.LightStateKind:
 		publishLightState(ctx, commands, topics, *busEvent.LightState)
 	case event.MQTTConnectedKind:
-		if err := publishMQTTStartup(ctx, root, commands); err != nil {
+		if err := publishMQTTStartup(ctx, reg, commands); err != nil {
 			slog.Error("mqtt startup publish failed", "error", err)
 		}
 	}

--- a/internal/controller/dispatch.go
+++ b/internal/controller/dispatch.go
@@ -14,7 +14,7 @@ import (
 func dispatchEvent(
 	ctx context.Context,
 	root *entity.Root,
-	index *registry.Index,
+	index *registry.Registry,
 	sysfsCommands chan<- sysfs.Command,
 	mqttCommands chan<- mqtt.Command,
 	mqttTopics mqtt.Topics,
@@ -28,14 +28,14 @@ func dispatchEvent(
 	return derivedEvents
 }
 
-func dispatchSysfsCommand(ctx context.Context, index *registry.Index, commands chan<- sysfs.Command, busEvent event.Event) {
+func dispatchSysfsCommand(ctx context.Context, index *registry.Registry, commands chan<- sysfs.Command, busEvent event.Event) {
 	switch busEvent.Kind {
 	case event.LightKind:
 		dispatchLightEvent(ctx, index, commands, *busEvent.Light)
 	}
 }
 
-func dispatchMQTTCommand(ctx context.Context, root *entity.Root, index *registry.Index, commands chan<- mqtt.Command, topics mqtt.Topics, busEvent event.Event) {
+func dispatchMQTTCommand(ctx context.Context, root *entity.Root, index *registry.Registry, commands chan<- mqtt.Command, topics mqtt.Topics, busEvent event.Event) {
 	switch busEvent.Kind {
 	case event.PushButtonPressedKind, event.PushButtonReleasedKind:
 		publishPushButtonSourceEvent(ctx, index, commands, topics, busEvent.Kind, *busEvent.PushButton)
@@ -79,7 +79,7 @@ func logPushButtonEvent(eventKind event.Kind, pushButton event.PushButton) {
 	)
 }
 
-func dispatchLightEvent(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, lightEvent event.Light) {
+func dispatchLightEvent(ctx context.Context, index *registry.Registry, sysfsCommands chan<- sysfs.Command, lightEvent event.Light) {
 	switch lightEvent.Action {
 	case entity.LightActionToggle:
 		handleLightToggle(ctx, index, sysfsCommands, lightEvent)

--- a/internal/controller/light.go
+++ b/internal/controller/light.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
-func handleLightToggle(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, lightEvent event.Light) {
+func handleLightToggle(ctx context.Context, index *registry.Registry, sysfsCommands chan<- sysfs.Command, lightEvent event.Light) {
 	light, ok := registry.LightByID(index, lightEvent.LightID)
 	if !ok {
 		slog.Error("unknown light", "light_id", lightEvent.LightID)
@@ -39,7 +39,7 @@ func handleLightToggle(ctx context.Context, index *registry.Index, sysfsCommands
 	)
 }
 
-func handleLightSet(ctx context.Context, index *registry.Index, sysfsCommands chan<- sysfs.Command, lightEvent event.Light, commandKind sysfs.CommandKind) {
+func handleLightSet(ctx context.Context, index *registry.Registry, sysfsCommands chan<- sysfs.Command, lightEvent event.Light, commandKind sysfs.CommandKind) {
 	light, ok := registry.LightByID(index, lightEvent.LightID)
 	if !ok {
 		slog.Error("unknown light", "light_id", lightEvent.LightID)
@@ -70,11 +70,11 @@ func handleLightSet(ctx context.Context, index *registry.Index, sysfsCommands ch
 	)
 }
 
-func relayToggleCommandForLight(index *registry.Index, light entity.Light) (sysfs.Command, bool) {
+func relayToggleCommandForLight(index *registry.Registry, light entity.Light) (sysfs.Command, bool) {
 	return relayCommandForLight(index, light, sysfs.ToggleCommand)
 }
 
-func relayCommandForLight(index *registry.Index, light entity.Light, commandKind sysfs.CommandKind) (sysfs.Command, bool) {
+func relayCommandForLight(index *registry.Registry, light entity.Light, commandKind sysfs.CommandKind) (sysfs.Command, bool) {
 	relay, ok := registry.RelayByID(index, light.Relay)
 	if !ok {
 		slog.Error("light references unknown relay", "light_id", light.ID, "relay_id", light.Relay)

--- a/internal/controller/mqtt.go
+++ b/internal/controller/mqtt.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mhemeryck/nest/internal/registry"
 )
 
-func publishPushButtonSourceEvent(ctx context.Context, index *registry.Index, commands chan<- mqtt.Command, topics mqtt.Topics, eventKind event.Kind, pushButton event.PushButton) {
+func publishPushButtonSourceEvent(ctx context.Context, index *registry.Registry, commands chan<- mqtt.Command, topics mqtt.Topics, eventKind event.Kind, pushButton event.PushButton) {
 	if len(registry.RemoteSourceBindingsByButton(index, pushButton.ButtonID)) == 0 {
 		return
 	}

--- a/internal/controller/normalize.go
+++ b/internal/controller/normalize.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
-func pushButtonEventsFromStateChange(index *registry.Index, stateChange sysfs.StateChange) ([]event.Event, bool) {
+func pushButtonEventsFromStateChange(index *registry.Registry, stateChange sysfs.StateChange) ([]event.Event, bool) {
 	input, ok := registry.DigitalInputBySysfsDevice(index, entity.SysfsDeviceID(stateChange.Device.Identifier))
 	if !ok {
 		return nil, false
@@ -33,7 +33,7 @@ func pushButtonEventsFromStateChange(index *registry.Index, stateChange sysfs.St
 	return buttonEvents, true
 }
 
-func semanticEventsFromStateChange(index *registry.Index, stateChange sysfs.StateChange) ([]event.Event, bool) {
+func semanticEventsFromStateChange(index *registry.Registry, stateChange sysfs.StateChange) ([]event.Event, bool) {
 	deviceID := entity.SysfsDeviceID(stateChange.Device.Identifier)
 	if input, ok := registry.DigitalInputBySysfsDevice(index, deviceID); ok {
 		events := []event.Event{{

--- a/internal/mqtt/ha_discovery.go
+++ b/internal/mqtt/ha_discovery.go
@@ -37,23 +37,23 @@ type HomeAssistantComponentDiscovery struct {
 	PayloadOff         string `json:"payload_off"`
 }
 
-func BuildHomeAssistantDeviceDiscovery(root *entity.Root, topics Topics) HomeAssistantDeviceDiscovery {
+func BuildHomeAssistantDeviceDiscovery(lights []entity.Light, topics Topics) HomeAssistantDeviceDiscovery {
 	doc := HomeAssistantDeviceDiscovery{
 		Device:            homeAssistantDevice(topics),
 		Origin:            HomeAssistantOrigin{Name: "nest"},
-		Components:        make(map[string]HomeAssistantComponentDiscovery, len(root.Lights)),
+		Components:        make(map[string]HomeAssistantComponentDiscovery, len(lights)),
 		AvailabilityTopic: AvailabilityTopic(topics),
 	}
 
-	for _, light := range root.Lights {
+	for _, light := range lights {
 		doc.Components[lightTopicSegment(light.ID)] = homeAssistantLightComponent(light, topics)
 	}
 
 	return doc
 }
 
-func HomeAssistantDeviceDiscoveryPayload(root *entity.Root, topics Topics) ([]byte, error) {
-	payload, err := json.Marshal(BuildHomeAssistantDeviceDiscovery(root, topics))
+func HomeAssistantDeviceDiscoveryPayload(lights []entity.Light, topics Topics) ([]byte, error) {
+	payload, err := json.Marshal(BuildHomeAssistantDeviceDiscovery(lights, topics))
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +61,8 @@ func HomeAssistantDeviceDiscoveryPayload(root *entity.Root, topics Topics) ([]by
 	return payload, nil
 }
 
-func HomeAssistantDeviceDiscoveryMessage(root *entity.Root, topics Topics) (PublishMessage, error) {
-	payload, err := HomeAssistantDeviceDiscoveryPayload(root, topics)
+func HomeAssistantDeviceDiscoveryMessage(lights []entity.Light, topics Topics) (PublishMessage, error) {
+	payload, err := HomeAssistantDeviceDiscoveryPayload(lights, topics)
 	if err != nil {
 		return PublishMessage{}, err
 	}

--- a/internal/mqtt/ha_discovery_test.go
+++ b/internal/mqtt/ha_discovery_test.go
@@ -41,7 +41,7 @@ func TestBuildHomeAssistantDeviceDiscovery(t *testing.T) {
 	root := testEntityRoot()
 	topics := NewTopics("nest", "controller_1")
 
-	doc := BuildHomeAssistantDeviceDiscovery(root, topics)
+	doc := BuildHomeAssistantDeviceDiscovery(root.Lights, topics)
 
 	assert.Equal(t, HomeAssistantDevice{
 		Identifiers:  []string{"nest_controller_1_unit"},
@@ -69,7 +69,7 @@ func TestBuildHomeAssistantDeviceDiscoveryWithSemanticLightID(t *testing.T) {
 	root.Lights[0].ID = entity.LightID("controller_1.light.office_light")
 	topics := NewTopics("nest", "controller_1")
 
-	doc := BuildHomeAssistantDeviceDiscovery(root, topics)
+	doc := BuildHomeAssistantDeviceDiscovery(root.Lights, topics)
 
 	require.Contains(t, doc.Components, "office_light")
 	assert.Equal(t, HomeAssistantComponentDiscovery{
@@ -86,7 +86,7 @@ func TestBuildHomeAssistantDeviceDiscoveryWithSemanticLightID(t *testing.T) {
 }
 
 func TestHomeAssistantDeviceDiscoveryPayload(t *testing.T) {
-	payload, err := HomeAssistantDeviceDiscoveryPayload(testEntityRoot(), NewTopics("nest", "controller_1"))
+	payload, err := HomeAssistantDeviceDiscoveryPayload(testEntityRoot().Lights, NewTopics("nest", "controller_1"))
 	require.NoError(t, err)
 
 	var doc HomeAssistantDeviceDiscovery
@@ -96,7 +96,7 @@ func TestHomeAssistantDeviceDiscoveryPayload(t *testing.T) {
 }
 
 func TestHomeAssistantDeviceDiscoveryMessage(t *testing.T) {
-	message, err := HomeAssistantDeviceDiscoveryMessage(testEntityRoot(), NewTopics("nest", "controller_1"))
+	message, err := HomeAssistantDeviceDiscoveryMessage(testEntityRoot().Lights, NewTopics("nest", "controller_1"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "homeassistant/device/nest_controller_1_unit/config", message.Topic)

--- a/internal/mqtt/startup.go
+++ b/internal/mqtt/startup.go
@@ -2,9 +2,9 @@ package mqtt
 
 import "github.com/mhemeryck/nest/internal/entity"
 
-func StartupCommands(root *entity.Root) ([]Command, error) {
-	topics := NewTopics(root.MQTT.TopicPrefix, root.MQTT.UnitID)
-	homeAssistantDiscovery, err := HomeAssistantDeviceDiscoveryMessage(root, topics)
+func StartupCommands(cfg entity.MQTT, lights []entity.Light) ([]Command, error) {
+	topics := NewTopics(cfg.TopicPrefix, cfg.UnitID)
+	homeAssistantDiscovery, err := HomeAssistantDeviceDiscoveryMessage(lights, topics)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mqtt/startup_test.go
+++ b/internal/mqtt/startup_test.go
@@ -9,24 +9,17 @@ import (
 )
 
 func TestStartupCommands(t *testing.T) {
-	root := &entity.Root{
-		MQTT: entity.MQTT{
-			TopicPrefix: "nest",
-			UnitID:      "controller_1",
-		},
-		Relays: []entity.Relay{{
-			ID:          entity.RelayID("office_light_relay"),
-			Name:        "Office light relay",
-			SysfsDevice: entity.SysfsDeviceID("ro_3_14"),
-		}},
-		Lights: []entity.Light{{
-			ID:    entity.LightID("office_light"),
-			Name:  "Office light",
-			Relay: entity.RelayID("office_light_relay"),
-		}},
+	cfg := entity.MQTT{
+		TopicPrefix: "nest",
+		UnitID:      "controller_1",
 	}
+	lights := []entity.Light{{
+		ID:    entity.LightID("office_light"),
+		Name:  "Office light",
+		Relay: entity.RelayID("office_light_relay"),
+	}}
 
-	commands, err := StartupCommands(root)
+	commands, err := StartupCommands(cfg, lights)
 	require.NoError(t, err)
 	require.Len(t, commands, 2)
 

--- a/internal/mqtt/topics.go
+++ b/internal/mqtt/topics.go
@@ -56,10 +56,10 @@ func SemanticSourceEventTopic(topics Topics, sourceID entity.ID) string {
 	return joinTopic(topics, "units", unitID, "sources", string(sourceID), "event")
 }
 
-func SemanticSourceEventSubscriptionTopics(topics Topics, root *entity.Root) []string {
-	seen := make(map[string]struct{}, len(root.RemoteTargetBindings))
-	subscriptions := make([]string, 0, len(root.RemoteTargetBindings))
-	for _, binding := range root.RemoteTargetBindings {
+func SemanticSourceEventSubscriptionTopics(topics Topics, bindings []entity.Binding) []string {
+	seen := make(map[string]struct{}, len(bindings))
+	subscriptions := make([]string, 0, len(bindings))
+	for _, binding := range bindings {
 		topic := SemanticSourceEventTopic(topics, binding.Source)
 		if _, ok := seen[topic]; ok {
 			continue

--- a/internal/mqtt/topics_test.go
+++ b/internal/mqtt/topics_test.go
@@ -27,12 +27,10 @@ func TestTopics(t *testing.T) {
 }
 
 func TestSemanticSourceEventSubscriptionTopics(t *testing.T) {
-	topics := SemanticSourceEventSubscriptionTopics(NewTopics("nest", "controller_1"), &entity.Root{
-		RemoteTargetBindings: []entity.Binding{
-			{Source: entity.ID("controller_2.button.hall_button"), Target: entity.ID("controller_1.light.office_light"), Action: entity.ActionToggle},
-			{Source: entity.ID("controller_2.button.hall_button"), Target: entity.ID("controller_1.light.desk_light"), Action: entity.ActionToggle},
-			{Source: entity.ID("controller_3.button.entry_button"), Target: entity.ID("controller_1.light.office_light"), Action: entity.ActionToggle},
-		},
+	topics := SemanticSourceEventSubscriptionTopics(NewTopics("nest", "controller_1"), []entity.Binding{
+		{Source: entity.ID("controller_2.button.hall_button"), Target: entity.ID("controller_1.light.office_light"), Action: entity.ActionToggle},
+		{Source: entity.ID("controller_2.button.hall_button"), Target: entity.ID("controller_1.light.desk_light"), Action: entity.ActionToggle},
+		{Source: entity.ID("controller_3.button.entry_button"), Target: entity.ID("controller_1.light.office_light"), Action: entity.ActionToggle},
 	})
 
 	assert.Equal(t, []string{

--- a/internal/nest/devices.go
+++ b/internal/nest/devices.go
@@ -11,14 +11,15 @@ import (
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
-func sysfsDevices(root *entity.Root, index *registry.Registry) ([]*sysfs.Device, error) {
-	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
-	devices, err := sysfs.ListDevices(root.SysfsRoot)
+func sysfsDevices(reg *registry.Registry) ([]*sysfs.Device, error) {
+	sysfsRoot := registry.SysfsRoot(reg)
+	slog.Info("crawling sysfs device tree", "root", sysfsRoot)
+	devices, err := sysfs.ListDevices(sysfsRoot)
 	if err != nil {
 		return nil, fmt.Errorf("crawl sysfs: %w", err)
 	}
 
-	configured, missing := configuredDevices(devices, registry.SysfsDeviceIDs(index))
+	configured, missing := configuredDevices(devices, registry.SysfsDeviceIDs(reg))
 	if len(missing) > 0 {
 		return nil, missingDevicesError(missing)
 	}

--- a/internal/nest/devices.go
+++ b/internal/nest/devices.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
 
-func sysfsDevices(root *entity.Root, index *registry.Index) ([]*sysfs.Device, error) {
+func sysfsDevices(root *entity.Root, index *registry.Registry) ([]*sysfs.Device, error) {
 	slog.Info("crawling sysfs device tree", "root", root.SysfsRoot)
 	devices, err := sysfs.ListDevices(root.SysfsRoot)
 	if err != nil {

--- a/internal/nest/modbus.go
+++ b/internal/nest/modbus.go
@@ -3,20 +3,21 @@ package nest
 import (
 	"log/slog"
 
-	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/registry"
 )
 
-func logModbusConfig(root *entity.Root) {
-	if root.Modbus.Mode == "" {
+func logModbusConfig(reg *registry.Registry) {
+	modbus := registry.Modbus(reg)
+	if modbus.Mode == "" {
 		return
 	}
 
 	slog.Info(
 		"modbus route intents configured",
-		"mode", root.Modbus.Mode,
-		"event_signals", len(root.Modbus.EventSignals),
-		"state_points", len(root.Modbus.StatePoints),
-		"event_signal_writes", len(root.Modbus.EventSignalWrites),
-		"state_polls", len(root.Modbus.StatePolls),
+		"mode", modbus.Mode,
+		"event_signals", len(modbus.EventSignals),
+		"state_points", len(modbus.StatePoints),
+		"event_signal_writes", len(modbus.EventSignalWrites),
+		"state_polls", len(modbus.StatePolls),
 	)
 }

--- a/internal/nest/modbus_test.go
+++ b/internal/nest/modbus_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mhemeryck/nest/internal/entity"
+	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,13 +16,13 @@ func TestLogModbusConfigLogsConfiguredRouteIntents(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buffer, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	logModbusConfig(&entity.Root{
+	logModbusConfig(registry.Build(&entity.Root{
 		Modbus: entity.Modbus{
 			Mode:              entity.ModbusModeMaster,
 			EventSignalWrites: []entity.ModbusEventSignalWrite{{}},
 			StatePolls:        []entity.ModbusStatePoll{{}},
 		},
-	})
+	}))
 
 	log := buffer.String()
 	assert.Contains(t, log, "modbus route intents configured")
@@ -36,7 +37,7 @@ func TestLogModbusConfigSkipsUnconfiguredModbus(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buffer, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	logModbusConfig(&entity.Root{})
+	logModbusConfig(registry.Build(&entity.Root{}))
 
 	assert.Empty(t, buffer.String())
 }

--- a/internal/nest/mqtt.go
+++ b/internal/nest/mqtt.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/mqtt"
+	"github.com/mhemeryck/nest/internal/registry"
 )
 
 type mqttActor struct {
@@ -17,12 +18,13 @@ type mqttActor struct {
 	cfg               entity.MQTT
 }
 
-func newMQTTActor(root *entity.Root) mqttActor {
-	if !root.MQTT.Enabled {
+func newMQTTActor(reg *registry.Registry) mqttActor {
+	cfg := registry.MQTT(reg)
+	if !cfg.Enabled {
 		return mqttActor{}
 	}
 
-	topics := mqtt.NewTopics(root.MQTT.TopicPrefix, root.MQTT.UnitID)
+	topics := mqtt.NewTopics(cfg.TopicPrefix, cfg.UnitID)
 
 	return mqttActor{
 		enabled:           true,
@@ -30,8 +32,8 @@ func newMQTTActor(root *entity.Root) mqttActor {
 		events:            make(chan mqtt.Event, 32),
 		done:              make(chan struct{}),
 		topics:            topics,
-		sourceEventTopics: mqtt.SemanticSourceEventSubscriptionTopics(topics, root),
-		cfg:               root.MQTT,
+		sourceEventTopics: mqtt.SemanticSourceEventSubscriptionTopics(topics, registry.RemoteTargetBindings(reg)),
+		cfg:               cfg,
 	}
 }
 

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 
 	"github.com/mhemeryck/nest/internal/config"
-	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/registry"
 )
 
@@ -20,7 +19,7 @@ func Run(ctx context.Context, opts Options) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	root, index, err := loadConfig(opts)
+	reg, err := loadRegistry(opts)
 	if err != nil {
 		return err
 	}
@@ -30,17 +29,17 @@ func Run(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	mqttActor := newMQTTActor(root)
-	sysfsActor, err := newSysfsActor(root, index)
+	mqttActor := newMQTTActor(reg)
+	sysfsActor, err := newSysfsActor(reg)
 	if err != nil {
 		return err
 	}
-	logModbusConfig(root)
+	logModbusConfig(reg)
 
 	startMQTTActor(ctx, mqttActor)
 	startSysfsActor(ctx, sysfsActor)
 
-	controllerDone := startController(ctx, root, index, sysfsActor, mqttActor)
+	controllerDone := startController(ctx, reg, sysfsActor, mqttActor)
 
 	slog.Info("runtime started", "message", "press Ctrl+C to exit")
 
@@ -50,14 +49,14 @@ func Run(ctx context.Context, opts Options) error {
 	return nil
 }
 
-func loadConfig(opts Options) (*entity.Root, *registry.Registry, error) {
+func loadRegistry(opts Options) (*registry.Registry, error) {
 	configRoot, err := config.Load(opts.ConfigPath, opts.UnitID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load config: %w", err)
+		return nil, fmt.Errorf("load config: %w", err)
 	}
 
 	root := config.ToEntityRoot(configRoot)
-	index := registry.Build(root)
+	reg := registry.Build(root)
 
-	return root, index, nil
+	return reg, nil
 }

--- a/internal/nest/nest.go
+++ b/internal/nest/nest.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, opts Options) error {
 	return nil
 }
 
-func loadConfig(opts Options) (*entity.Root, *registry.Index, error) {
+func loadConfig(opts Options) (*entity.Root, *registry.Registry, error) {
 	configRoot, err := config.Load(opts.ConfigPath, opts.UnitID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load config: %w", err)

--- a/internal/nest/runtime.go
+++ b/internal/nest/runtime.go
@@ -4,22 +4,19 @@ import (
 	"context"
 
 	"github.com/mhemeryck/nest/internal/controller"
-	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/registry"
 )
 
 func startController(
 	ctx context.Context,
-	root *entity.Root,
-	index *registry.Registry,
+	reg *registry.Registry,
 	sysfsActor sysfsActor,
 	mqttActor mqttActor,
 ) <-chan struct{} {
 	done := make(chan struct{})
 	go controller.Run(
 		ctx,
-		root,
-		index,
+		reg,
 		sysfsActor.commands,
 		mqttActor.commands,
 		mqttActor.topics,

--- a/internal/nest/runtime.go
+++ b/internal/nest/runtime.go
@@ -11,7 +11,7 @@ import (
 func startController(
 	ctx context.Context,
 	root *entity.Root,
-	index *registry.Index,
+	index *registry.Registry,
 	sysfsActor sysfsActor,
 	mqttActor mqttActor,
 ) <-chan struct{} {

--- a/internal/nest/sysfs.go
+++ b/internal/nest/sysfs.go
@@ -16,7 +16,7 @@ type sysfsActor struct {
 	pollIntervals sysfs.PollIntervals
 }
 
-func newSysfsActor(root *entity.Root, index *registry.Index) (sysfsActor, error) {
+func newSysfsActor(root *entity.Root, index *registry.Registry) (sysfsActor, error) {
 	devices, err := sysfsDevices(root, index)
 	if err != nil {
 		return sysfsActor{}, err

--- a/internal/nest/sysfs.go
+++ b/internal/nest/sysfs.go
@@ -3,7 +3,6 @@ package nest
 import (
 	"context"
 
-	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/mhemeryck/nest/internal/registry"
 	"github.com/mhemeryck/nest/internal/sysfs"
 )
@@ -16,8 +15,8 @@ type sysfsActor struct {
 	pollIntervals sysfs.PollIntervals
 }
 
-func newSysfsActor(root *entity.Root, index *registry.Registry) (sysfsActor, error) {
-	devices, err := sysfsDevices(root, index)
+func newSysfsActor(reg *registry.Registry) (sysfsActor, error) {
+	devices, err := sysfsDevices(reg)
 	if err != nil {
 		return sysfsActor{}, err
 	}
@@ -28,7 +27,7 @@ func newSysfsActor(root *entity.Root, index *registry.Registry) (sysfsActor, err
 		states:        make(chan sysfs.StateChange, 32),
 		done:          make(chan struct{}),
 		devices:       devices,
-		pollIntervals: sysfsPollIntervals(root),
+		pollIntervals: sysfsPollIntervals(reg),
 	}, nil
 }
 
@@ -41,10 +40,12 @@ func waitForSysfsActor(actor sysfsActor) {
 	close(actor.states)
 }
 
-func sysfsPollIntervals(root *entity.Root) sysfs.PollIntervals {
+func sysfsPollIntervals(reg *registry.Registry) sysfs.PollIntervals {
+	pollIntervals := registry.SysfsPollIntervals(reg)
+
 	return sysfs.PollIntervals{
-		DigitalInput:  root.SysfsPollIntervals.DigitalInput,
-		DigitalOutput: root.SysfsPollIntervals.DigitalOutput,
-		RelayOutput:   root.SysfsPollIntervals.RelayOutput,
+		DigitalInput:  pollIntervals.DigitalInput,
+		DigitalOutput: pollIntervals.DigitalOutput,
+		RelayOutput:   pollIntervals.RelayOutput,
 	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mhemeryck/nest/internal/entity"
 )
 
-type Index struct {
+type Registry struct {
 	DigitalInputsByDevice          map[entity.SysfsDeviceID]entity.DigitalInput
 	PushButtonsByID                map[entity.PushButtonID]entity.PushButton
 	PushButtonsByInputID           map[entity.DigitalInputID][]entity.PushButton
@@ -19,8 +19,8 @@ type Index struct {
 	RelaysByDevice                 map[entity.SysfsDeviceID]entity.Relay
 }
 
-func Build(root *entity.Root) *Index {
-	index := &Index{
+func Build(root *entity.Root) *Registry {
+	index := &Registry{
 		DigitalInputsByDevice:          make(map[entity.SysfsDeviceID]entity.DigitalInput, len(root.DigitalInputs)),
 		PushButtonsByID:                make(map[entity.PushButtonID]entity.PushButton, len(root.PushButtons)),
 		PushButtonsByInputID:           make(map[entity.DigitalInputID][]entity.PushButton),
@@ -67,7 +67,7 @@ func Build(root *entity.Root) *Index {
 	return index
 }
 
-func SysfsDeviceIDs(index *Index) []entity.SysfsDeviceID {
+func SysfsDeviceIDs(index *Registry) []entity.SysfsDeviceID {
 	deviceIDs := make([]entity.SysfsDeviceID, 0, len(index.DigitalInputsByDevice)+len(index.RelaysByDevice))
 	for deviceID := range index.DigitalInputsByDevice {
 		deviceIDs = append(deviceIDs, deviceID)
@@ -81,54 +81,54 @@ func SysfsDeviceIDs(index *Index) []entity.SysfsDeviceID {
 	return deviceIDs
 }
 
-func DigitalInputBySysfsDevice(index *Index, deviceID entity.SysfsDeviceID) (entity.DigitalInput, bool) {
+func DigitalInputBySysfsDevice(index *Registry, deviceID entity.SysfsDeviceID) (entity.DigitalInput, bool) {
 	input, ok := index.DigitalInputsByDevice[deviceID]
 	return input, ok
 }
 
-func PushButtonsByInput(index *Index, inputID entity.DigitalInputID) []entity.PushButton {
+func PushButtonsByInput(index *Registry, inputID entity.DigitalInputID) []entity.PushButton {
 	return index.PushButtonsByInputID[inputID]
 }
 
-func BindingsByButton(index *Index, buttonID entity.PushButtonID) []entity.Binding {
+func BindingsByButton(index *Registry, buttonID entity.PushButtonID) []entity.Binding {
 	return BindingsBySource(index, entity.ID(buttonID))
 }
 
-func BindingsBySource(index *Index, sourceID entity.ID) []entity.Binding {
+func BindingsBySource(index *Registry, sourceID entity.ID) []entity.Binding {
 	return index.BindingsBySourceID[sourceID]
 }
 
-func RemoteSourceBindingsByButton(index *Index, buttonID entity.PushButtonID) []entity.Binding {
+func RemoteSourceBindingsByButton(index *Registry, buttonID entity.PushButtonID) []entity.Binding {
 	return RemoteSourceBindingsBySource(index, entity.ID(buttonID))
 }
 
-func RemoteSourceBindingsBySource(index *Index, sourceID entity.ID) []entity.Binding {
+func RemoteSourceBindingsBySource(index *Registry, sourceID entity.ID) []entity.Binding {
 	return index.RemoteSourceBindingsBySourceID[sourceID]
 }
 
-func RemoteTargetBindingsByButton(index *Index, buttonID entity.PushButtonID) []entity.Binding {
+func RemoteTargetBindingsByButton(index *Registry, buttonID entity.PushButtonID) []entity.Binding {
 	return RemoteTargetBindingsBySource(index, entity.ID(buttonID))
 }
 
-func RemoteTargetBindingsBySource(index *Index, sourceID entity.ID) []entity.Binding {
+func RemoteTargetBindingsBySource(index *Registry, sourceID entity.ID) []entity.Binding {
 	return index.RemoteTargetBindingsBySourceID[sourceID]
 }
 
-func LightByID(index *Index, lightID entity.LightID) (entity.Light, bool) {
+func LightByID(index *Registry, lightID entity.LightID) (entity.Light, bool) {
 	light, ok := index.LightsByID[lightID]
 	return light, ok
 }
 
-func LightsByRelay(index *Index, relayID entity.RelayID) []entity.Light {
+func LightsByRelay(index *Registry, relayID entity.RelayID) []entity.Light {
 	return index.LightsByRelayID[relayID]
 }
 
-func RelayByID(index *Index, relayID entity.RelayID) (entity.Relay, bool) {
+func RelayByID(index *Registry, relayID entity.RelayID) (entity.Relay, bool) {
 	relay, ok := index.RelaysByID[relayID]
 	return relay, ok
 }
 
-func RelayBySysfsDevice(index *Index, deviceID entity.SysfsDeviceID) (entity.Relay, bool) {
+func RelayBySysfsDevice(index *Registry, deviceID entity.SysfsDeviceID) (entity.Relay, bool) {
 	relay, ok := index.RelaysByDevice[deviceID]
 	return relay, ok
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,6 +7,12 @@ import (
 )
 
 type Registry struct {
+	sysfsRoot                      string
+	sysfsPollIntervals             entity.PollIntervals
+	mqtt                           entity.MQTT
+	modbus                         entity.Modbus
+	lights                         []entity.Light
+	remoteTargetBindings           []entity.Binding
 	DigitalInputsByDevice          map[entity.SysfsDeviceID]entity.DigitalInput
 	PushButtonsByID                map[entity.PushButtonID]entity.PushButton
 	PushButtonsByInputID           map[entity.DigitalInputID][]entity.PushButton
@@ -21,6 +27,12 @@ type Registry struct {
 
 func Build(root *entity.Root) *Registry {
 	index := &Registry{
+		sysfsRoot:                      root.SysfsRoot,
+		sysfsPollIntervals:             root.SysfsPollIntervals,
+		mqtt:                           root.MQTT,
+		modbus:                         copyModbus(root.Modbus),
+		lights:                         append([]entity.Light(nil), root.Lights...),
+		remoteTargetBindings:           append([]entity.Binding(nil), root.RemoteTargetBindings...),
 		DigitalInputsByDevice:          make(map[entity.SysfsDeviceID]entity.DigitalInput, len(root.DigitalInputs)),
 		PushButtonsByID:                make(map[entity.PushButtonID]entity.PushButton, len(root.PushButtons)),
 		PushButtonsByInputID:           make(map[entity.DigitalInputID][]entity.PushButton),
@@ -65,6 +77,40 @@ func Build(root *entity.Root) *Registry {
 	}
 
 	return index
+}
+
+func SysfsRoot(reg *Registry) string {
+	return reg.sysfsRoot
+}
+
+func SysfsPollIntervals(reg *Registry) entity.PollIntervals {
+	return reg.sysfsPollIntervals
+}
+
+func MQTT(reg *Registry) entity.MQTT {
+	return reg.mqtt
+}
+
+func Modbus(reg *Registry) entity.Modbus {
+	return copyModbus(reg.modbus)
+}
+
+func Lights(reg *Registry) []entity.Light {
+	return append([]entity.Light(nil), reg.lights...)
+}
+
+func RemoteTargetBindings(reg *Registry) []entity.Binding {
+	return append([]entity.Binding(nil), reg.remoteTargetBindings...)
+}
+
+func copyModbus(modbus entity.Modbus) entity.Modbus {
+	return entity.Modbus{
+		Mode:              modbus.Mode,
+		EventSignals:      append([]entity.ModbusEventSignal(nil), modbus.EventSignals...),
+		StatePoints:       append([]entity.ModbusStatePoint(nil), modbus.StatePoints...),
+		EventSignalWrites: append([]entity.ModbusEventSignalWrite(nil), modbus.EventSignalWrites...),
+		StatePolls:        append([]entity.ModbusStatePoll(nil), modbus.StatePolls...),
+	}
 }
 
 func SysfsDeviceIDs(index *Registry) []entity.SysfsDeviceID {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -13,16 +13,16 @@ type Registry struct {
 	modbus                         entity.Modbus
 	lights                         []entity.Light
 	remoteTargetBindings           []entity.Binding
-	DigitalInputsByDevice          map[entity.SysfsDeviceID]entity.DigitalInput
-	PushButtonsByID                map[entity.PushButtonID]entity.PushButton
-	PushButtonsByInputID           map[entity.DigitalInputID][]entity.PushButton
-	LightsByID                     map[entity.LightID]entity.Light
-	LightsByRelayID                map[entity.RelayID][]entity.Light
-	BindingsBySourceID             map[entity.ID][]entity.Binding
-	RemoteSourceBindingsBySourceID map[entity.ID][]entity.Binding
-	RemoteTargetBindingsBySourceID map[entity.ID][]entity.Binding
-	RelaysByID                     map[entity.RelayID]entity.Relay
-	RelaysByDevice                 map[entity.SysfsDeviceID]entity.Relay
+	digitalInputsByDevice          map[entity.SysfsDeviceID]entity.DigitalInput
+	pushButtonsByID                map[entity.PushButtonID]entity.PushButton
+	pushButtonsByInputID           map[entity.DigitalInputID][]entity.PushButton
+	lightsByID                     map[entity.LightID]entity.Light
+	lightsByRelayID                map[entity.RelayID][]entity.Light
+	bindingsBySourceID             map[entity.ID][]entity.Binding
+	remoteSourceBindingsBySourceID map[entity.ID][]entity.Binding
+	remoteTargetBindingsBySourceID map[entity.ID][]entity.Binding
+	relaysByID                     map[entity.RelayID]entity.Relay
+	relaysByDevice                 map[entity.SysfsDeviceID]entity.Relay
 }
 
 func Build(root *entity.Root) *Registry {
@@ -31,49 +31,49 @@ func Build(root *entity.Root) *Registry {
 		sysfsPollIntervals:             root.SysfsPollIntervals,
 		mqtt:                           root.MQTT,
 		modbus:                         copyModbus(root.Modbus),
-		lights:                         append([]entity.Light(nil), root.Lights...),
-		remoteTargetBindings:           append([]entity.Binding(nil), root.RemoteTargetBindings...),
-		DigitalInputsByDevice:          make(map[entity.SysfsDeviceID]entity.DigitalInput, len(root.DigitalInputs)),
-		PushButtonsByID:                make(map[entity.PushButtonID]entity.PushButton, len(root.PushButtons)),
-		PushButtonsByInputID:           make(map[entity.DigitalInputID][]entity.PushButton),
-		LightsByID:                     make(map[entity.LightID]entity.Light, len(root.Lights)),
-		LightsByRelayID:                make(map[entity.RelayID][]entity.Light),
-		BindingsBySourceID:             make(map[entity.ID][]entity.Binding),
-		RemoteSourceBindingsBySourceID: make(map[entity.ID][]entity.Binding),
-		RemoteTargetBindingsBySourceID: make(map[entity.ID][]entity.Binding),
-		RelaysByID:                     make(map[entity.RelayID]entity.Relay, len(root.Relays)),
-		RelaysByDevice:                 make(map[entity.SysfsDeviceID]entity.Relay, len(root.Relays)),
+		lights:                         slices.Clone(root.Lights),
+		remoteTargetBindings:           slices.Clone(root.RemoteTargetBindings),
+		digitalInputsByDevice:          make(map[entity.SysfsDeviceID]entity.DigitalInput, len(root.DigitalInputs)),
+		pushButtonsByID:                make(map[entity.PushButtonID]entity.PushButton, len(root.PushButtons)),
+		pushButtonsByInputID:           make(map[entity.DigitalInputID][]entity.PushButton),
+		lightsByID:                     make(map[entity.LightID]entity.Light, len(root.Lights)),
+		lightsByRelayID:                make(map[entity.RelayID][]entity.Light),
+		bindingsBySourceID:             make(map[entity.ID][]entity.Binding),
+		remoteSourceBindingsBySourceID: make(map[entity.ID][]entity.Binding),
+		remoteTargetBindingsBySourceID: make(map[entity.ID][]entity.Binding),
+		relaysByID:                     make(map[entity.RelayID]entity.Relay, len(root.Relays)),
+		relaysByDevice:                 make(map[entity.SysfsDeviceID]entity.Relay, len(root.Relays)),
 	}
 
 	for _, input := range root.DigitalInputs {
-		index.DigitalInputsByDevice[input.SysfsDevice] = input
+		index.digitalInputsByDevice[input.SysfsDevice] = input
 	}
 
 	for _, button := range root.PushButtons {
-		index.PushButtonsByID[button.ID] = button
-		index.PushButtonsByInputID[button.Input] = append(index.PushButtonsByInputID[button.Input], button)
+		index.pushButtonsByID[button.ID] = button
+		index.pushButtonsByInputID[button.Input] = append(index.pushButtonsByInputID[button.Input], button)
 	}
 
 	for _, light := range root.Lights {
-		index.LightsByID[light.ID] = light
-		index.LightsByRelayID[light.Relay] = append(index.LightsByRelayID[light.Relay], light)
+		index.lightsByID[light.ID] = light
+		index.lightsByRelayID[light.Relay] = append(index.lightsByRelayID[light.Relay], light)
 	}
 
 	for _, relay := range root.Relays {
-		index.RelaysByID[relay.ID] = relay
-		index.RelaysByDevice[relay.SysfsDevice] = relay
+		index.relaysByID[relay.ID] = relay
+		index.relaysByDevice[relay.SysfsDevice] = relay
 	}
 
 	for _, binding := range root.Bindings {
-		index.BindingsBySourceID[binding.Source] = append(index.BindingsBySourceID[binding.Source], binding)
+		index.bindingsBySourceID[binding.Source] = append(index.bindingsBySourceID[binding.Source], binding)
 	}
 
 	for _, binding := range root.RemoteSourceBindings {
-		index.RemoteSourceBindingsBySourceID[binding.Source] = append(index.RemoteSourceBindingsBySourceID[binding.Source], binding)
+		index.remoteSourceBindingsBySourceID[binding.Source] = append(index.remoteSourceBindingsBySourceID[binding.Source], binding)
 	}
 
 	for _, binding := range root.RemoteTargetBindings {
-		index.RemoteTargetBindingsBySourceID[binding.Source] = append(index.RemoteTargetBindingsBySourceID[binding.Source], binding)
+		index.remoteTargetBindingsBySourceID[binding.Source] = append(index.remoteTargetBindingsBySourceID[binding.Source], binding)
 	}
 
 	return index
@@ -96,29 +96,29 @@ func Modbus(reg *Registry) entity.Modbus {
 }
 
 func Lights(reg *Registry) []entity.Light {
-	return append([]entity.Light(nil), reg.lights...)
+	return slices.Clone(reg.lights)
 }
 
 func RemoteTargetBindings(reg *Registry) []entity.Binding {
-	return append([]entity.Binding(nil), reg.remoteTargetBindings...)
+	return slices.Clone(reg.remoteTargetBindings)
 }
 
 func copyModbus(modbus entity.Modbus) entity.Modbus {
 	return entity.Modbus{
 		Mode:              modbus.Mode,
-		EventSignals:      append([]entity.ModbusEventSignal(nil), modbus.EventSignals...),
-		StatePoints:       append([]entity.ModbusStatePoint(nil), modbus.StatePoints...),
-		EventSignalWrites: append([]entity.ModbusEventSignalWrite(nil), modbus.EventSignalWrites...),
-		StatePolls:        append([]entity.ModbusStatePoll(nil), modbus.StatePolls...),
+		EventSignals:      slices.Clone(modbus.EventSignals),
+		StatePoints:       slices.Clone(modbus.StatePoints),
+		EventSignalWrites: slices.Clone(modbus.EventSignalWrites),
+		StatePolls:        slices.Clone(modbus.StatePolls),
 	}
 }
 
 func SysfsDeviceIDs(index *Registry) []entity.SysfsDeviceID {
-	deviceIDs := make([]entity.SysfsDeviceID, 0, len(index.DigitalInputsByDevice)+len(index.RelaysByDevice))
-	for deviceID := range index.DigitalInputsByDevice {
+	deviceIDs := make([]entity.SysfsDeviceID, 0, len(index.digitalInputsByDevice)+len(index.relaysByDevice))
+	for deviceID := range index.digitalInputsByDevice {
 		deviceIDs = append(deviceIDs, deviceID)
 	}
-	for deviceID := range index.RelaysByDevice {
+	for deviceID := range index.relaysByDevice {
 		deviceIDs = append(deviceIDs, deviceID)
 	}
 
@@ -128,12 +128,12 @@ func SysfsDeviceIDs(index *Registry) []entity.SysfsDeviceID {
 }
 
 func DigitalInputBySysfsDevice(index *Registry, deviceID entity.SysfsDeviceID) (entity.DigitalInput, bool) {
-	input, ok := index.DigitalInputsByDevice[deviceID]
+	input, ok := index.digitalInputsByDevice[deviceID]
 	return input, ok
 }
 
 func PushButtonsByInput(index *Registry, inputID entity.DigitalInputID) []entity.PushButton {
-	return index.PushButtonsByInputID[inputID]
+	return slices.Clone(index.pushButtonsByInputID[inputID])
 }
 
 func BindingsByButton(index *Registry, buttonID entity.PushButtonID) []entity.Binding {
@@ -141,7 +141,7 @@ func BindingsByButton(index *Registry, buttonID entity.PushButtonID) []entity.Bi
 }
 
 func BindingsBySource(index *Registry, sourceID entity.ID) []entity.Binding {
-	return index.BindingsBySourceID[sourceID]
+	return slices.Clone(index.bindingsBySourceID[sourceID])
 }
 
 func RemoteSourceBindingsByButton(index *Registry, buttonID entity.PushButtonID) []entity.Binding {
@@ -149,7 +149,7 @@ func RemoteSourceBindingsByButton(index *Registry, buttonID entity.PushButtonID)
 }
 
 func RemoteSourceBindingsBySource(index *Registry, sourceID entity.ID) []entity.Binding {
-	return index.RemoteSourceBindingsBySourceID[sourceID]
+	return slices.Clone(index.remoteSourceBindingsBySourceID[sourceID])
 }
 
 func RemoteTargetBindingsByButton(index *Registry, buttonID entity.PushButtonID) []entity.Binding {
@@ -157,24 +157,24 @@ func RemoteTargetBindingsByButton(index *Registry, buttonID entity.PushButtonID)
 }
 
 func RemoteTargetBindingsBySource(index *Registry, sourceID entity.ID) []entity.Binding {
-	return index.RemoteTargetBindingsBySourceID[sourceID]
+	return slices.Clone(index.remoteTargetBindingsBySourceID[sourceID])
 }
 
 func LightByID(index *Registry, lightID entity.LightID) (entity.Light, bool) {
-	light, ok := index.LightsByID[lightID]
+	light, ok := index.lightsByID[lightID]
 	return light, ok
 }
 
 func LightsByRelay(index *Registry, relayID entity.RelayID) []entity.Light {
-	return index.LightsByRelayID[relayID]
+	return slices.Clone(index.lightsByRelayID[relayID])
 }
 
 func RelayByID(index *Registry, relayID entity.RelayID) (entity.Relay, bool) {
-	relay, ok := index.RelaysByID[relayID]
+	relay, ok := index.relaysByID[relayID]
 	return relay, ok
 }
 
 func RelayBySysfsDevice(index *Registry, deviceID entity.SysfsDeviceID) (entity.Relay, bool) {
-	relay, ok := index.RelaysByDevice[deviceID]
+	relay, ok := index.relaysByDevice[deviceID]
 	return relay, ok
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mhemeryck/nest/internal/entity"
 	"github.com/stretchr/testify/assert"
@@ -96,4 +97,100 @@ func TestLookupHelpers(t *testing.T) {
 	relay, ok = RelayBySysfsDevice(index, entity.SysfsDeviceID("ro_3_14"))
 	require.True(t, ok)
 	assert.Equal(t, root.Relays[0], relay)
+}
+
+func TestRuntimeDataHelpers(t *testing.T) {
+	root := &entity.Root{
+		SysfsRoot: "/sys/test",
+		SysfsPollIntervals: entity.PollIntervals{
+			DigitalInput:  100 * time.Millisecond,
+			DigitalOutput: 200 * time.Millisecond,
+			RelayOutput:   300 * time.Millisecond,
+		},
+		MQTT: entity.MQTT{
+			Enabled:     true,
+			Host:        "mqtt.local",
+			Port:        1883,
+			ClientID:    "nest-test",
+			Username:    "nest",
+			Password:    "secret",
+			TopicPrefix: "nest",
+			UnitID:      "controller_1",
+		},
+		Modbus: entity.Modbus{
+			Mode: entity.ModbusModeMaster,
+			EventSignals: []entity.ModbusEventSignal{
+				{
+					ID:     entity.ModbusEventSignalID("office_button_signal"),
+					Source: entity.ID("controller_1.button.office_button"),
+					Target: entity.ID("controller_2.light.office_light"),
+					Action: entity.ActionToggle,
+				},
+			},
+			StatePoints: []entity.ModbusStatePoint{
+				{
+					ID:     entity.ModbusStatePointID("office_light_state"),
+					Entity: entity.ID("controller_2.light.office_light"),
+				},
+			},
+			EventSignalWrites: []entity.ModbusEventSignalWrite{
+				{
+					Unit:   "controller_2",
+					Signal: entity.ModbusEventSignalID("office_button_signal"),
+					Source: entity.ID("controller_1.button.office_button"),
+					Target: entity.ID("controller_2.light.office_light"),
+					Action: entity.ActionToggle,
+				},
+			},
+			StatePolls: []entity.ModbusStatePoll{
+				{
+					Unit:   "controller_2",
+					Point:  entity.ModbusStatePointID("office_light_state"),
+					Entity: entity.ID("controller_2.light.office_light"),
+				},
+			},
+		},
+		Lights: []entity.Light{
+			{ID: entity.LightID("office_light"), Name: "Office light", Relay: entity.RelayID("office_light_relay")},
+		},
+		RemoteTargetBindings: []entity.Binding{
+			{Source: entity.ID("controller_2.button.hall_button"), Target: entity.ID("controller_1.light.office_light"), Action: entity.ActionToggle},
+		},
+	}
+	reg := Build(root)
+
+	assert.Equal(t, root.SysfsRoot, SysfsRoot(reg))
+	assert.Equal(t, root.SysfsPollIntervals, SysfsPollIntervals(reg))
+	assert.Equal(t, root.MQTT, MQTT(reg))
+	assert.Equal(t, root.Modbus, Modbus(reg))
+	assert.Equal(t, root.Lights, Lights(reg))
+	assert.Equal(t, root.RemoteTargetBindings, RemoteTargetBindings(reg))
+}
+
+func TestRuntimeDataHelpersReturnCopies(t *testing.T) {
+	root := &entity.Root{
+		Modbus: entity.Modbus{
+			EventSignals: []entity.ModbusEventSignal{
+				{ID: entity.ModbusEventSignalID("office_button_signal")},
+			},
+		},
+		Lights: []entity.Light{
+			{ID: entity.LightID("office_light"), Name: "Office light", Relay: entity.RelayID("office_light_relay")},
+		},
+		RemoteTargetBindings: []entity.Binding{
+			{Source: entity.ID("controller_2.button.hall_button"), Target: entity.ID("controller_1.light.office_light"), Action: entity.ActionToggle},
+		},
+	}
+	reg := Build(root)
+
+	modbus := Modbus(reg)
+	modbus.EventSignals[0].ID = entity.ModbusEventSignalID("changed_signal")
+	lights := Lights(reg)
+	lights[0].Name = "Changed light"
+	bindings := RemoteTargetBindings(reg)
+	bindings[0].Action = entity.Action("changed")
+
+	assert.Equal(t, root.Modbus, Modbus(reg))
+	assert.Equal(t, root.Lights, Lights(reg))
+	assert.Equal(t, root.RemoteTargetBindings, RemoteTargetBindings(reg))
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -34,20 +34,30 @@ func TestBuild(t *testing.T) {
 		},
 	}
 
-	index := Build(root)
-	require.NotNil(t, index)
+	reg := Build(root)
+	require.NotNil(t, reg)
 
-	assert.Equal(t, root.DigitalInputs[0], index.DigitalInputsByDevice[entity.SysfsDeviceID("di_3_16")])
-	assert.Equal(t, root.PushButtons[0], index.PushButtonsByID[entity.PushButtonID("office_button")])
-	assert.Equal(t, root.PushButtons, index.PushButtonsByInputID[entity.DigitalInputID("office_button_input")])
-	assert.Equal(t, root.Lights[0], index.LightsByID[entity.LightID("office_light")])
-	assert.Equal(t, root.Lights, index.LightsByRelayID[entity.RelayID("office_light_relay")])
-	assert.Equal(t, root.Bindings, index.BindingsBySourceID[entity.ID("office_button")])
-	assert.Equal(t, root.RemoteSourceBindings, index.RemoteSourceBindingsBySourceID[entity.ID("controller_1.button.office_button")])
-	assert.Equal(t, root.RemoteTargetBindings, index.RemoteTargetBindingsBySourceID[entity.ID("controller_2.button.hall_button")])
-	assert.Equal(t, root.Relays[0], index.RelaysByID[entity.RelayID("office_light_relay")])
-	assert.Equal(t, root.Relays[0], index.RelaysByDevice[entity.SysfsDeviceID("ro_3_14")])
-	assert.Equal(t, []entity.SysfsDeviceID{"di_3_16", "ro_3_14"}, SysfsDeviceIDs(index))
+	input, ok := DigitalInputBySysfsDevice(reg, entity.SysfsDeviceID("di_3_16"))
+	require.True(t, ok)
+	assert.Equal(t, root.DigitalInputs[0], input)
+	assert.Equal(t, root.PushButtons, PushButtonsByInput(reg, entity.DigitalInputID("office_button_input")))
+	assert.Equal(t, root.Lights, LightsByRelay(reg, entity.RelayID("office_light_relay")))
+	assert.Equal(t, root.Bindings, BindingsBySource(reg, entity.ID("office_button")))
+	assert.Equal(t, root.RemoteSourceBindings, RemoteSourceBindingsBySource(reg, entity.ID("controller_1.button.office_button")))
+	assert.Equal(t, root.RemoteTargetBindings, RemoteTargetBindingsBySource(reg, entity.ID("controller_2.button.hall_button")))
+	assert.Equal(t, []entity.SysfsDeviceID{"di_3_16", "ro_3_14"}, SysfsDeviceIDs(reg))
+
+	light, ok := LightByID(reg, entity.LightID("office_light"))
+	require.True(t, ok)
+	assert.Equal(t, root.Lights[0], light)
+
+	relay, ok := RelayByID(reg, entity.RelayID("office_light_relay"))
+	require.True(t, ok)
+	assert.Equal(t, root.Relays[0], relay)
+
+	relay, ok = RelayBySysfsDevice(reg, entity.SysfsDeviceID("ro_3_14"))
+	require.True(t, ok)
+	assert.Equal(t, root.Relays[0], relay)
 }
 
 func TestLookupHelpers(t *testing.T) {
@@ -193,4 +203,42 @@ func TestRuntimeDataHelpersReturnCopies(t *testing.T) {
 	assert.Equal(t, root.Modbus, Modbus(reg))
 	assert.Equal(t, root.Lights, Lights(reg))
 	assert.Equal(t, root.RemoteTargetBindings, RemoteTargetBindings(reg))
+}
+
+func TestLookupHelpersReturnCopies(t *testing.T) {
+	root := &entity.Root{
+		PushButtons: []entity.PushButton{
+			{ID: entity.PushButtonID("office_button"), Name: "Office button", Input: entity.DigitalInputID("office_button_input")},
+		},
+		Lights: []entity.Light{
+			{ID: entity.LightID("office_light"), Name: "Office light", Relay: entity.RelayID("office_light_relay")},
+		},
+		Bindings: []entity.Binding{
+			{Source: entity.ID("office_button"), Target: entity.ID("office_light"), Action: entity.ActionToggle},
+		},
+		RemoteSourceBindings: []entity.Binding{
+			{Source: entity.ID("controller_1.button.office_button"), Target: entity.ID("controller_2.light.hall_light"), Action: entity.ActionToggle},
+		},
+		RemoteTargetBindings: []entity.Binding{
+			{Source: entity.ID("controller_2.button.hall_button"), Target: entity.ID("controller_1.light.office_light"), Action: entity.ActionToggle},
+		},
+	}
+	reg := Build(root)
+
+	pushButtons := PushButtonsByInput(reg, entity.DigitalInputID("office_button_input"))
+	pushButtons[0].Name = "Changed button"
+	lights := LightsByRelay(reg, entity.RelayID("office_light_relay"))
+	lights[0].Name = "Changed light"
+	bindings := BindingsBySource(reg, entity.ID("office_button"))
+	bindings[0].Action = entity.Action("changed")
+	remoteSourceBindings := RemoteSourceBindingsBySource(reg, entity.ID("controller_1.button.office_button"))
+	remoteSourceBindings[0].Action = entity.Action("changed")
+	remoteTargetBindings := RemoteTargetBindingsBySource(reg, entity.ID("controller_2.button.hall_button"))
+	remoteTargetBindings[0].Action = entity.Action("changed")
+
+	assert.Equal(t, root.PushButtons, PushButtonsByInput(reg, entity.DigitalInputID("office_button_input")))
+	assert.Equal(t, root.Lights, LightsByRelay(reg, entity.RelayID("office_light_relay")))
+	assert.Equal(t, root.Bindings, BindingsBySource(reg, entity.ID("office_button")))
+	assert.Equal(t, root.RemoteSourceBindings, RemoteSourceBindingsBySource(reg, entity.ID("controller_1.button.office_button")))
+	assert.Equal(t, root.RemoteTargetBindings, RemoteTargetBindingsBySource(reg, entity.ID("controller_2.button.hall_button")))
 }


### PR DESCRIPTION
Make the registry the runtime lookup and translation catalog used by
nest and controller wiring.

This keeps entity.Root as the bare projected domain model while
runtime code depends on a single registry value. Registry internals are
now read-only through package-level query functions, which avoids
callers mutating lookup maps or slice backing arrays.
